### PR TITLE
Fix INP set parser

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TopOpt"
 uuid = "53a1e1a5-51bb-58a9-8a02-02056cc81109"
 authors = ["mohamed82008 <mohamed82008@gmail.com>", "yijiangh <yijiang94817@gmail.com>"]
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/src/TopOptProblems/IO/INP/Parser/FeatureExtractors/extract_set.jl
+++ b/src/TopOptProblems/IO/INP/Parser/FeatureExtractors/extract_set.jl
@@ -9,12 +9,14 @@ function extract_set!(
     line = readline(file)
     m = match(stopping_pattern, line)
     while m isa Nothing
-        m = match(pattern_single, line)
-        if m != nothing
-            push!(vector, parse(TI, m[1]) - offset)
+        if match(pattern_single, line) !== nothing
+            m = eachmatch(r"(\d+)", line)
+            for _m in m
+                push!(vector, parse(TI, _m.match) - offset)
+            end
         else
             m = match(pattern_subset, line)
-            if m != nothing
+            if m !== nothing
                 subsetname = String(m[1])
                 if haskey(sets, subsetname)
                     append!(vector, sets[subsetname])

--- a/test/inp_parser/parser.jl
+++ b/test/inp_parser/parser.jl
@@ -30,6 +30,7 @@ force_node = collect(keys(raw_inp.cloads))[1]
 @test raw_inp.dloads["DLOAD_SET_1"] == 1
 
 @test raw_inp.nodedbcs["FemConstraintDisplacement"] == [(1, 0), (2, 0), (3, 0)]
+@test raw_inp.nodesets["FemConstraintDisplacement"] == [1, 3, 5, 7, 13, 14, 15, 16, 22]
 for n in raw_inp.nodesets["FemConstraintDisplacement"]
     @test raw_inp.node_coords[n][3] == 0
 end

--- a/test/inp_parser/testcube.inp
+++ b/test/inp_parser/testcube.inp
@@ -56,9 +56,7 @@ Evolumes
 ** written by write_node_sets_constraints_displacement function
 ** FemConstraintDisplacement
 *NSET,NSET=FemConstraintDisplacement
-1,
-3,
-5,
+1,3, 5,
 7,
 13,
 14,


### PR DESCRIPTION
The INP set parser previously assumed that there is only 1 node per line. This PR relaxes this constraint.