### PR TITLE
Speeding up the stress tensor jacobian using ForwardDiff per element

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TopOpt"
 uuid = "53a1e1a5-51bb-58a9-8a02-02056cc81109"
 authors = ["mohamed82008 <mohamed82008@gmail.com>", "yijiangh <yijiang94817@gmail.com>"]
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/test/examples/local_stress.jl
+++ b/test/examples/local_stress.jl
@@ -39,7 +39,7 @@ threshold = 3 * maximum(stress(filter(PseudoDensities(x0))))
 x = copy(x0)
 x .= 1
 for p in 1.0:1.0:3.0
-    global x
+    global x, solver, stress, filter, volfrac, obj, constr, alg, options, model, r
     penalty = TopOpt.PowerPenalty(p)
     # Define a finite element solver
     solver = FEASolver(Direct, problem; xmin=xmin, penalty=penalty)


### PR DESCRIPTION
### Summary

This PR speeds up the gradient calculation of the stress tensor per element using ForwardDiff instead of Zygote per element. Zygote is still the main AD package used but ForwardDiff is used to define a rule.