### PR TITLE
Use Julia 1.10 in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1'
+          - '1.10'
         os:
           - ubuntu-latest
         arch:
@@ -61,7 +61,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        version: ['1',]
+        version: ['1.10',]
         os: ['ubuntu-latest',]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### Summary

Julia 1.11 seems to cause a segfault in CI. This PR forces CI to use Julia 1.10 until the issue is resolved.