### PR TITLE
Add SVD mean compliance tests and fix stress tensor typo

### DIFF
--- a/src/Functions/stress_tensor.jl
+++ b/src/Functions/stress_tensor.jl
@@ -57,7 +57,7 @@ function (f::ElementStressTensor)(u::DisplacementResult; element_dofs=false)
     st = f.stress_tensor
     reinit!(f, f.cellidx)
     if element_dofs
-        return _element_stres_tensor(f, u)
+        return _element_stress_tensor(f, u)
     else
         return _element_stress_tensor(f, DisplacementResult(u.u[copy(st.global_dofs)]))
     end

--- a/src/TopOptProblems/assemble.jl
+++ b/src/TopOptProblems/assemble.jl
@@ -88,7 +88,7 @@ function assemble_f(
     assemble_f!(f, problem, elementinfo, vars, penalty, xmin)
     return f
 end
-get_f(problem, vars::Array) = zeros(T, ndofs(problem.ch.dh))
+get_f(problem, vars::Array) = zeros(floattype(problem), ndofs(problem.ch.dh))
 
 function assemble_f!(
     f::AbstractVector,

--- a/test/Functions/test_common_fns.jl
+++ b/test/Functions/test_common_fns.jl
@@ -48,6 +48,22 @@ end
     end
 end
 
+@testset "Compliance - Vector input warning" begin
+    nels = (2, 2)
+    problem = HalfMBB(Val{:Linear}, nels, (1.0, 1.0), 1.0, 0.3, 1.0)
+    solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(3.0))
+    comp = Compliance(solver)
+    
+    # Create a simple density vector
+    n_vars = length(solver.vars)
+    x = ones(n_vars) * 0.5
+    
+    # Test that vector input produces a warning and returns valid result
+    result = @test_logs (:warn, r"A vector input was passed in to the compliance function") comp(x)
+    @test isfinite(result)
+    @test result > 0
+end
+
 @testset "Displacement" begin
     nels = (2, 2)
     problem = HalfMBB(Val{:Linear}, nels, (1.0, 1.0), 1.0, 0.3, 1.0)

--- a/test/Functions/test_compute_mean_compliance_svd.jl
+++ b/test/Functions/test_compute_mean_compliance_svd.jl
@@ -1,0 +1,347 @@
+using TopOpt, Test, LinearAlgebra, Random, SparseArrays, FiniteDifferences, Zygote
+using TopOpt: Nonconvex, Functions
+
+const FDM = FiniteDifferences
+
+Random.seed!(42)
+
+@testset "compute_mean_compliance with TraceEstimationSVDMean" begin
+
+    @testset "Basic functionality - function returns finite value" begin
+        # Create a simple problem
+        E = 1.0
+        ν = 0.3
+        force = 1.0
+        nels = (4, 4)
+
+        base_problem = PointLoadCantilever(Val{:Linear}, nels, (1.0, 1.0), E, ν, force)
+
+        # Create multiple load cases
+        nloads = 3
+        F = spzeros(TopOpt.Ferrite.ndofs(base_problem.ch.dh), nloads)
+        dense_load_inds = vec(TopOpt.TopOptProblems.get_surface_dofs(base_problem))
+        for i in 1:nloads
+            dofs = dense_load_inds[rand(1:length(dense_load_inds), 2)]
+            F[dofs, i] .= randn(2)
+        end
+
+        problem = MultiLoad(base_problem, F)
+        solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+
+        # Create MeanCompliance with TraceEstimationSVDMean method
+        mc = MeanCompliance(problem, solver; method=:approx_svd, nv=5)
+
+        # Verify it's using TraceEstimationSVDMean
+        @test mc.method isa Functions.TraceEstimationSVDMean
+
+        # Get the method object
+        ax = mc.method
+
+        # Prepare inputs
+        x = fill(0.5, length(solver.vars))
+        grad = similar(x)
+
+        # Call the specific dispatch
+        val = Functions.compute_mean_compliance(mc, ax, x, grad)
+
+        # Verify results
+        @test isfinite(val)
+        @test val > 0
+        @test all(isfinite.(grad))
+        @test length(grad) == length(x)
+    end
+
+    @testset "Consistency with compute_approx_ec" begin
+        # Verify the function calls compute_approx_ec correctly
+        E = 1.0
+        ν = 0.3
+        force = 1.0
+        nels = (4, 4)
+
+        base_problem = PointLoadCantilever(Val{:Linear}, nels, (1.0, 1.0), E, ν, force)
+
+        nloads = 3
+        F = spzeros(TopOpt.Ferrite.ndofs(base_problem.ch.dh), nloads)
+        dense_load_inds = vec(TopOpt.TopOptProblems.get_surface_dofs(base_problem))
+        for i in 1:nloads
+            dofs = dense_load_inds[rand(1:length(dense_load_inds), 2)]
+            F[dofs, i] .= randn(2)
+        end
+
+        problem = MultiLoad(base_problem, F)
+        solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+
+        mc = MeanCompliance(problem, solver; method=:approx_svd, nv=5)
+        ax = mc.method
+
+        x = fill(0.5, length(solver.vars))
+        grad = similar(x)
+
+        # Call via dispatch
+        val1 = Functions.compute_mean_compliance(mc, ax, x, grad)
+        grad1 = copy(grad)
+
+        # Call compute_approx_ec directly with same parameters
+        grad .= 0
+        val2 = Functions.compute_approx_ec(mc, x, grad, ax.US, ax.V, ax.n)
+
+        # Results should match
+        @test isapprox(val1, val2; rtol=1e-10)
+        @test isapprox(grad1, grad; rtol=1e-10)
+    end
+
+    @testset "Different sample counts" begin
+        E = 1.0
+        ν = 0.3
+        force = 1.0
+        nels = (4, 4)
+
+        base_problem = PointLoadCantilever(Val{:Linear}, nels, (1.0, 1.0), E, ν, force)
+
+        nloads = 3
+        F = spzeros(TopOpt.Ferrite.ndofs(base_problem.ch.dh), nloads)
+        dense_load_inds = vec(TopOpt.TopOptProblems.get_surface_dofs(base_problem))
+        for i in 1:nloads
+            dofs = dense_load_inds[rand(1:length(dense_load_inds), 2)]
+            F[dofs, i] .= randn(2)
+        end
+
+        problem = MultiLoad(base_problem, F)
+        solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+
+        # Test with different sample counts
+        for nv in [1, 3, 5]
+            mc = MeanCompliance(problem, solver; method=:approx_svd, nv=nv)
+            ax = mc.method
+
+            x = fill(0.5, length(solver.vars))
+            grad = similar(x)
+
+            val = Functions.compute_mean_compliance(mc, ax, x, grad)
+
+            @test isfinite(val)
+            @test val > 0
+            @test all(isfinite.(grad))
+        end
+    end
+
+    @testset "Different density values" begin
+        E = 1.0
+        ν = 0.3
+        force = 1.0
+        nels = (4, 4)
+
+        base_problem = PointLoadCantilever(Val{:Linear}, nels, (1.0, 1.0), E, ν, force)
+
+        nloads = 3
+        F = spzeros(TopOpt.Ferrite.ndofs(base_problem.ch.dh), nloads)
+        dense_load_inds = vec(TopOpt.TopOptProblems.get_surface_dofs(base_problem))
+        for i in 1:nloads
+            dofs = dense_load_inds[rand(1:length(dense_load_inds), 2)]
+            F[dofs, i] .= randn(2)
+        end
+
+        problem = MultiLoad(base_problem, F)
+        solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+
+        mc = MeanCompliance(problem, solver; method=:approx_svd, nv=5)
+        ax = mc.method
+
+        # Test with different density values
+        for rho in [0.2, 0.5, 0.8, 0.95]
+            x = fill(rho, length(solver.vars))
+            grad = similar(x)
+
+            val = Functions.compute_mean_compliance(mc, ax, x, grad)
+
+            @test isfinite(val)
+            @test val > 0
+            @test all(isfinite.(grad))
+
+            # Compliance should decrease with higher density
+            # (this is a physical property, not strict requirement)
+        end
+    end
+
+    @testset "Gradient accumulation" begin
+        E = 1.0
+        ν = 0.3
+        force = 1.0
+        nels = (4, 4)
+
+        base_problem = PointLoadCantilever(Val{:Linear}, nels, (1.0, 1.0), E, ν, force)
+
+        nloads = 3
+        F = spzeros(TopOpt.Ferrite.ndofs(base_problem.ch.dh), nloads)
+        dense_load_inds = vec(TopOpt.TopOptProblems.get_surface_dofs(base_problem))
+        for i in 1:nloads
+            dofs = dense_load_inds[rand(1:length(dense_load_inds), 2)]
+            F[dofs, i] .= randn(2)
+        end
+
+        problem = MultiLoad(base_problem, F)
+        solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+
+        mc = MeanCompliance(problem, solver; method=:approx_svd, nv=5)
+        ax = mc.method
+
+        x = fill(0.5, length(solver.vars))
+
+        # Test that gradient is properly accumulated (not just overwritten)
+        grad_pre = ones(length(x))
+        grad = copy(grad_pre)
+
+        Functions.compute_mean_compliance(mc, ax, x, grad)
+
+        # Gradient should be updated
+        @test !iszero(grad)
+    end
+
+    @testset "Compare with ExactSVDMean" begin
+        # TraceEstimationSVDMean should approximate ExactSVDMean
+        E = 1.0
+        ν = 0.3
+        force = 1.0
+        nels = (4, 4)
+
+        base_problem = PointLoadCantilever(Val{:Linear}, nels, (1.0, 1.0), E, ν, force)
+
+        nloads = 3
+        F = spzeros(TopOpt.Ferrite.ndofs(base_problem.ch.dh), nloads)
+        dense_load_inds = vec(TopOpt.TopOptProblems.get_surface_dofs(base_problem))
+        for i in 1:nloads
+            dofs = dense_load_inds[rand(1:length(dense_load_inds), 2)]
+            F[dofs, i] .= randn(2)
+        end
+
+        problem = MultiLoad(base_problem, F)
+        solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+
+        # Exact SVD
+        mc_exact = MeanCompliance(problem, solver; method=:exact_svd)
+        x = fill(0.5, length(solver.vars))
+        grad_exact = similar(x)
+        val_exact = Functions.compute_mean_compliance(mc_exact, mc_exact.method, x, grad_exact)
+
+        # Approximate SVD with many samples
+        mc_approx = MeanCompliance(problem, solver; method=:approx_svd, nv=20)
+        ax = mc_approx.method
+        grad_approx = similar(x)
+        val_approx = Functions.compute_mean_compliance(mc_approx, ax, x, grad_approx)
+
+        # Should be reasonably close (within 30% for trace estimation)
+        @test abs(val_approx - val_exact) / val_exact < 0.3
+    end
+
+    @testset "Method fields are correctly structured" begin
+        E = 1.0
+        ν = 0.3
+        force = 1.0
+        nels = (4, 4)
+
+        base_problem = PointLoadCantilever(Val{:Linear}, nels, (1.0, 1.0), E, ν, force)
+
+        nloads = 3
+        F = spzeros(TopOpt.Ferrite.ndofs(base_problem.ch.dh), nloads)
+        dense_load_inds = vec(TopOpt.TopOptProblems.get_surface_dofs(base_problem))
+        for i in 1:nloads
+            dofs = dense_load_inds[rand(1:length(dense_load_inds), 2)]
+            F[dofs, i] .= randn(2)
+        end
+
+        problem = MultiLoad(base_problem, F)
+        solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+
+        mc = MeanCompliance(problem, solver; method=:approx_svd, nv=5)
+        ax = mc.method
+
+        # Verify structure
+        @test ax.n == nloads
+        @test size(ax.US, 1) == TopOpt.Ferrite.ndofs(base_problem.ch.dh)
+        @test size(ax.V, 2) == 5  # nv samples
+
+        # US should be sparse (from SVD)
+        @test ax.US isa SparseMatrixCSC
+
+        # V should contain Rademacher samples
+        @test all(abs.(ax.V) .== 1.0)
+
+        x = fill(0.5, length(solver.vars))
+        grad = similar(x)
+
+        val = Functions.compute_mean_compliance(mc, ax, x, grad)
+
+        @test isfinite(val)
+    end
+
+    @testset "Different sample methods" begin
+        E = 1.0
+        ν = 0.3
+        force = 1.0
+        nels = (4, 4)
+
+        base_problem = PointLoadCantilever(Val{:Linear}, nels, (1.0, 1.0), E, ν, force)
+
+        nloads = 3
+        F = spzeros(TopOpt.Ferrite.ndofs(base_problem.ch.dh), nloads)
+        dense_load_inds = vec(TopOpt.TopOptProblems.get_surface_dofs(base_problem))
+        for i in 1:nloads
+            dofs = dense_load_inds[rand(1:length(dense_load_inds), 2)]
+            F[dofs, i] .= randn(2)
+        end
+
+        problem = MultiLoad(base_problem, F)
+        solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+
+        x = fill(0.5, length(solver.vars))
+
+        for sample_method in [:hutch, :hadamard]
+            mc = MeanCompliance(problem, solver; method=:approx_svd, nv=5, sample_method=sample_method)
+            ax = mc.method
+            grad = similar(x)
+
+            val = Functions.compute_mean_compliance(mc, ax, x, grad)
+
+            @test isfinite(val)
+            @test val > 0
+            @test all(isfinite.(grad))
+        end
+    end
+
+    @testset "Integration with solver state" begin
+        E = 1.0
+        ν = 0.3
+        force = 1.0
+        nels = (4, 4)
+
+        base_problem = PointLoadCantilever(Val{:Linear}, nels, (1.0, 1.0), E, ν, force)
+
+        nloads = 3
+        F = spzeros(TopOpt.Ferrite.ndofs(base_problem.ch.dh), nloads)
+        dense_load_inds = vec(TopOpt.TopOptProblems.get_surface_dofs(base_problem))
+        for i in 1:nloads
+            dofs = dense_load_inds[rand(1:length(dense_load_inds), 2)]
+            F[dofs, i] .= randn(2)
+        end
+
+        problem = MultiLoad(base_problem, F)
+        solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+
+        mc = MeanCompliance(problem, solver; method=:approx_svd, nv=5)
+        ax = mc.method
+
+        x = fill(0.5, length(solver.vars))
+        grad = similar(x)
+
+        # First call
+        val1 = Functions.compute_mean_compliance(mc, ax, x, grad)
+
+        # Second call with same x should give same result
+        grad2 = similar(x)
+        val2 = Functions.compute_mean_compliance(mc, ax, x, grad2)
+
+        @test isapprox(val1, val2; rtol=1e-10)
+        @test isapprox(grad, grad2; rtol=1e-10)
+    end
+
+end

--- a/test/Functions/test_element_stress_tensor.jl
+++ b/test/Functions/test_element_stress_tensor.jl
@@ -1,0 +1,288 @@
+using TopOpt,
+    Zygote, LinearAlgebra, Test, Random, SparseArrays, ForwardDiff, ChainRulesCore
+using Ferrite: ndofs_per_cell, getncells, celldofs!
+using TopOpt.Functions: StressTensor, DisplacementResult, ElementStressTensor, reinit!, _element_stress_tensor
+
+Random.seed!(1)
+
+# Reference von Mises calculation for 2D (plane stress)
+function von_mises_reference_2d(σxx, σyy, σxy)
+    return sqrt(σxx^2 - σxx*σyy + σyy^2 + 3*σxy^2)
+end
+
+# Reference von Mises calculation for 3D (general stress state)
+function von_mises_reference_3d(σ)
+    σxx, σyy, σzz = σ[1,1], σ[2,2], σ[3,3]
+    σxy, σyz, σzx = σ[1,2], σ[2,3], σ[3,1]
+    
+    # Deviatoric stress components
+    σm = (σxx + σyy + σzz) / 3
+    sxx = σxx - σm
+    syy = σyy - σm
+    szz = σzz - σm
+    
+    # von Mises stress
+    return sqrt(1.5 * (sxx^2 + syy^2 + szz^2) + 3*(σxy^2 + σyz^2 + σzx^2))
+end
+
+@testset "ElementStressTensor call function" begin
+    nels = (2, 2)
+    problem = HalfMBB(Val{:Linear}, nels, (1.0, 1.0), 1.0, 0.3, 1.0)
+    solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(3.0))
+    
+    st = StressTensor(solver)
+    dp = Displacement(solver)
+    
+    # Get displacement result for testing
+    x = clamp.(rand(prod(nels)), 0.1, 1.0)
+    u = dp(PseudoDensities(x))
+    
+    @testset "Basic call with element_dofs=false (default)" begin
+        # Test calling ElementStressTensor with default element_dofs=false
+        for cellidx in 1:min(2, length(st.cells))
+            est = st[cellidx]
+            
+            # Call with element_dofs=false (default)
+            result = est(u; element_dofs=false)
+            
+            # Check result is a matrix (stress tensor)
+            @test isa(result, AbstractMatrix)
+            dim = TopOptProblems.getdim(problem)
+            @test size(result) == (dim, dim)
+            
+            # Check all values are finite
+            @test all(isfinite, result)
+        end
+    end
+    
+    @testset "Call with element_dofs=true" begin
+        # Test calling ElementStressTensor with element_dofs=true
+        for cellidx in 1:min(2, length(st.cells))
+            est = st[cellidx]
+            
+            # Get element dofs displacement result
+            dh = problem.ch.dh
+            n = ndofs_per_cell(dh)
+            global_dofs = zeros(Int, n)
+            celldofs!(global_dofs, dh, cellidx)
+            element_disp = DisplacementResult(u.u[global_dofs])
+            
+            # Call with element_dofs=true
+            result = est(element_disp; element_dofs=true)
+            
+            # Check result is a matrix (stress tensor)
+            @test isa(result, AbstractMatrix)
+            dim = TopOptProblems.getdim(problem)
+            @test size(result) == (dim, dim)
+            
+            # Check all values are finite
+            @test all(isfinite, result)
+        end
+    end
+    
+    @testset "Consistency between element_dofs modes" begin
+        # The results from both modes should be consistent when properly configured
+        cellidx = 1
+        est = st[cellidx]
+        
+        # Get element dofs displacement result
+        dh = problem.ch.dh
+        n = ndofs_per_cell(dh)
+        global_dofs = zeros(Int, n)
+        celldofs!(global_dofs, dh, cellidx)
+        element_disp = DisplacementResult(u.u[global_dofs])
+        
+        # Call with element_dofs=true
+        result_true = est(element_disp; element_dofs=true)
+        
+        # Call with element_dofs=false (uses global displacement)
+        result_false = est(u; element_dofs=false)
+        
+        # Both should return same stress tensor for the same element
+        @test size(result_true) == size(result_false)
+    end
+    
+    @testset "Stress tensor properties" begin
+        # Test that returned stress tensors have expected properties
+        cellidx = 1
+        est = st[cellidx]
+        
+        result = est(u; element_dofs=false)
+        
+        # For a symmetric stress tensor in linear elasticity
+        dim = TopOptProblems.getdim(problem)
+        @test size(result) == (dim, dim)
+        
+        # All diagonal elements should be real
+        for i in 1:dim
+            @test isreal(result[i, i])
+        end
+    end
+    
+    @testset "reinit! is called during evaluation" begin
+        # Test that reinit! properly updates internal state
+        cellidx = 1
+        est1 = st[cellidx]
+        
+        # First evaluation
+        result1 = est1(u; element_dofs=false)
+        
+        # Second evaluation - should give same result
+        result2 = est1(u; element_dofs=false)
+        
+        @test result1 ≈ result2
+        
+        # Different cell - should give different result
+        if length(st.cells) >= 2
+            est2 = st[2]
+            result3 = est2(u; element_dofs=false)
+            @test size(result3) == size(result1)
+        end
+    end
+    
+    @testset "Integration with gradient computation" begin
+        # Test that the call works within Zygote gradient computation
+        cellidx = 1
+        est = st[cellidx]
+        
+        # Define a scalar function based on stress tensor
+        f = x -> begin
+            u_local = dp(PseudoDensities(x))
+            σ = est(u_local; element_dofs=false)
+            return sum(abs2, σ)  # Sum of squared stresses
+        end
+        
+        x = clamp.(rand(prod(nels)), 0.1, 1.0)
+        
+        # Evaluate function
+        val = f(x)
+        @test isa(val, Real)
+        @test isfinite(val)
+        @test val >= 0  # Sum of squares should be non-negative
+        
+        # Compute gradient
+        grad = Zygote.gradient(f, x)[1]
+        @test length(grad) == length(x)
+        @test all(isfinite, grad)
+    end
+    
+    @testset "Stress tensor for different density values" begin
+        # Test stress computation with different density values
+        cellidx = 1
+        est = st[cellidx]
+        
+        # Low density
+        x_low = fill(0.1, prod(nels))
+        u_low = dp(PseudoDensities(x_low))
+        σ_low = est(u_low; element_dofs=false)
+        
+        # High density
+        x_high = fill(1.0, prod(nels))
+        u_high = dp(PseudoDensities(x_high))
+        σ_high = est(u_high; element_dofs=false)
+        
+        # Both should return valid stress tensors
+        @test all(isfinite, σ_low)
+        @test all(isfinite, σ_high)
+        @test size(σ_low) == size(σ_high)
+        
+        # Stress values should be different
+        @test σ_low != σ_high
+    end
+end
+
+@testset "von_mises function tests" begin
+    @testset "2D stress tensors" begin
+        σ1 = [100.0 0.0; 0.0 0.0]
+        @test TopOpt.Functions.von_mises(σ1) ≈ 100.0 atol = 1e-10
+        @test TopOpt.Functions.von_mises(σ1) ≈ von_mises_reference_2d(100.0, 0.0, 0.0)
+
+        σ2 = [0.0 0.0; 0.0 100.0]
+        @test TopOpt.Functions.von_mises(σ2) ≈ 100.0 atol = 1e-10
+        @test TopOpt.Functions.von_mises(σ2) ≈ von_mises_reference_2d(0.0, 100.0, 0.0)
+
+        σ3 = [100.0 0.0; 0.0 100.0]
+        @test TopOpt.Functions.von_mises(σ3) ≈ 100.0 atol = 1e-10
+        @test TopOpt.Functions.von_mises(σ3) ≈ von_mises_reference_2d(100.0, 100.0, 0.0)
+
+        σ4 = [0.0 50.0; 50.0 0.0]
+        @test TopOpt.Functions.von_mises(σ4) ≈ sqrt(3) * 50.0 atol = 1e-10
+        @test TopOpt.Functions.von_mises(σ4) ≈ von_mises_reference_2d(0.0, 0.0, 50.0)
+
+        σ5 = [100.0 50.0; 50.0 50.0]
+        expected = sqrt(100^2 - 100 * 50 + 50^2 + 3 * 50^2)
+        @test TopOpt.Functions.von_mises(σ5) ≈ expected atol = 1e-10
+        @test TopOpt.Functions.von_mises(σ5) ≈ von_mises_reference_2d(100.0, 50.0, 50.0)
+
+        σ6 = [0.0 0.0; 0.0 0.0]
+        @test TopOpt.Functions.von_mises(σ6) ≈ 0.0 atol = 1e-10
+
+        σ7 = [-50.0 30.0; 30.0 -30.0]
+        @test TopOpt.Functions.von_mises(σ7) ≈ von_mises_reference_2d(-50.0, -30.0, 30.0)
+
+        σ8 = [100 0; 0 50]
+        @test TopOpt.Functions.von_mises(σ8) ≈ sqrt(100^2 - 100 * 50 + 50^2) atol = 1e-10
+    end
+
+    @testset "3D stress tensors" begin
+        σ1 = [100.0 0.0 0.0; 0.0 0.0 0.0; 0.0 0.0 0.0]
+        @test TopOpt.Functions.von_mises(σ1) ≈ 100.0 atol = 1e-10
+        @test TopOpt.Functions.von_mises(σ1) ≈ von_mises_reference_3d(σ1)
+
+        σ2 = [100.0 0.0 0.0; 0.0 100.0 0.0; 0.0 0.0 100.0]
+        @test TopOpt.Functions.von_mises(σ2) ≈ 0.0 atol = 1e-10  # Hydrostatic stress has zero von Mises
+
+        σ3 = [0.0 50.0 0.0; 50.0 0.0 0.0; 0.0 0.0 0.0]
+        expected = sqrt(3) * 50.0
+        @test TopOpt.Functions.von_mises(σ3) ≈ expected atol = 1e-10
+        @test TopOpt.Functions.von_mises(σ3) ≈ von_mises_reference_3d(σ3)
+
+        σ4 = [100.0 30.0 20.0; 30.0 50.0 10.0; 20.0 10.0 25.0]
+        @test TopOpt.Functions.von_mises(σ4) ≈ von_mises_reference_3d(σ4)
+
+        σ5 = [0.0 0.0 0.0; 0.0 0.0 0.0; 0.0 0.0 0.0]
+        @test TopOpt.Functions.von_mises(σ5) ≈ 0.0 atol = 1e-10
+
+        σ6 = [0.0 0.0 0.0; 0.0 0.0 40.0; 0.0 40.0 0.0]
+        @test TopOpt.Functions.von_mises(σ6) ≈ sqrt(3) * 40.0 atol = 1e-10
+
+        σ7 = [0.0 0.0 60.0; 0.0 0.0 0.0; 60.0 0.0 0.0]
+        @test TopOpt.Functions.von_mises(σ7) ≈ sqrt(3) * 60.0 atol = 1e-10
+    end
+
+    @testset "Error handling" begin
+        σ1 = [100.0 0.0 0.0 0.0; 0.0 100.0 0.0 0.0; 0.0 0.0 100.0 0.0; 0.0 0.0 0.0 100.0]
+        @test_throws ArgumentError TopOpt.Functions.von_mises(σ1)
+
+        σ2 = [100.0]
+        @test_throws MethodError TopOpt.Functions.von_mises(σ2)
+    end
+
+    @testset "Type stability" begin
+        σ1 = Float32[100.0 0.0; 0.0 0.0]
+        result1 = TopOpt.Functions.von_mises(σ1)
+        @test typeof(result1) == Float32
+
+        σ2 = Float64[100.0 0.0; 0.0 0.0]
+        result2 = TopOpt.Functions.von_mises(σ2)
+        @test typeof(result2) == Float64
+
+        σ3 = [1e-10 0.0; 0.0 0.0]
+        @test TopOpt.Functions.von_mises(σ3) ≈ 1e-10 atol = 1e-20
+
+        σ4 = [1e10 0.0; 0.0 0.0]
+        @test TopOpt.Functions.von_mises(σ4) ≈ 1e10 atol = 1e-2
+    end
+
+    @testset "Symmetry preservation" begin
+        σ_base = [100.0 50.0 30.0; 50.0 80.0 20.0; 30.0 20.0 60.0]
+        σ_transpose = σ_base'
+        @test TopOpt.Functions.von_mises(σ_base) ≈ TopOpt.Functions.von_mises(σ_transpose)
+
+        σ_2d = [100.0 50.0; 50.0 80.0]
+        @test TopOpt.Functions.von_mises(σ_2d) ≈ TopOpt.Functions.von_mises(σ_2d')
+    end
+end
+
+println("All ElementStressTensor call tests passed!")
+println("All von_mises tests passed!")

--- a/test/Functions/test_fixed_element.jl
+++ b/test/Functions/test_fixed_element.jl
@@ -2,6 +2,7 @@ using Test, ChainRulesCore, Zygote, LinearAlgebra
 using TopOpt.Functions: FixedElementProjector, get_fixed_element_projector, 
                         get_free_variables, get_free_variable_count
 using Zygote: gradient
+using Ferrite: getncells
 
 # Helper function for finite difference gradient check
 function finite_diff_gradient(f, x::AbstractVector{T}, h=T(1e-6)) where T
@@ -33,6 +34,79 @@ end
         
         # Invalid: mismatched lengths
         @test_throws ArgumentError FixedElementProjector(5, falses(5), falses(6))
+    end
+    
+    @testset "get_free_variables" begin
+        # Basic case: mixed black, white, and free elements
+        black = falses(10); black[1:3] .= true
+        white = falses(10); white[8:10] .= true
+        p = FixedElementProjector(10, black, white)
+        
+        free_vars = get_free_variables(p)
+        @test free_vars isa BitVector
+        @test length(free_vars) == 10
+        @test free_vars == [false, false, false, true, true, true, true, false, false, false]
+        
+        # Verify free elements are exactly those not in black or white
+        @test all(free_vars .== (.!black .& .!white))
+        
+        # All black - no free elements
+        black_all = trues(5)
+        white_none = falses(5)
+        p_all_black = FixedElementProjector(5, black_all, white_none)
+        free_all_black = get_free_variables(p_all_black)
+        @test free_all_black isa BitVector
+        @test length(free_all_black) == 5
+        @test all(free_all_black .== false)
+        @test count(free_all_black) == 0
+        
+        # All white - no free elements
+        black_none = falses(5)
+        white_all = trues(5)
+        p_all_white = FixedElementProjector(5, black_none, white_all)
+        free_all_white = get_free_variables(p_all_white)
+        @test free_all_white isa BitVector
+        @test length(free_all_white) == 5
+        @test all(free_all_white .== false)
+        @test count(free_all_white) == 0
+        
+        # No fixed elements - all free
+        black_empty = falses(5)
+        white_empty = falses(5)
+        p_all_free = FixedElementProjector(5, black_empty, white_empty)
+        free_all_free = get_free_variables(p_all_free)
+        @test free_all_free isa BitVector
+        @test length(free_all_free) == 5
+        @test all(free_all_free .== true)
+        @test count(free_all_free) == 5
+        
+        # Single element cases
+        # One free element
+        p_single_free = FixedElementProjector(1, falses(1), falses(1))
+        free_single = get_free_variables(p_single_free)
+        @test free_single isa BitVector
+        @test length(free_single) == 1
+        @test free_single[1] == true
+        
+        # One black element
+        p_single_black = FixedElementProjector(1, trues(1), falses(1))
+        free_single_black = get_free_variables(p_single_black)
+        @test free_single_black isa BitVector
+        @test length(free_single_black) == 1
+        @test free_single_black[1] == false
+        
+        # One white element
+        p_single_white = FixedElementProjector(1, falses(1), trues(1))
+        free_single_white = get_free_variables(p_single_white)
+        @test free_single_white isa BitVector
+        @test length(free_single_white) == 1
+        @test free_single_white[1] == false
+        
+        # Verify consistency with get_free_variable_count
+        @test count(get_free_variables(p)) == get_free_variable_count(p)
+        @test count(get_free_variables(p_all_black)) == get_free_variable_count(p_all_black)
+        @test count(get_free_variables(p_all_white)) == get_free_variable_count(p_all_white)
+        @test count(get_free_variables(p_all_free)) == get_free_variable_count(p_all_free)
     end
     
     @testset "Direct calling" begin
@@ -108,6 +182,125 @@ end
     @test get_free_variable_count(p) == 80
     @test count(p.black) == 10
     @test count(p.white) == 10
+end
+
+@testset "get_fixed_element_projector (by problem)" begin
+    using TopOpt, TopOpt.TopOptProblems
+    
+    @testset "PointLoadCantilever" begin
+        # Create a 2D cantilever problem
+        nels = (10, 6)
+        problem = PointLoadCantilever(Val{:Linear}, nels, (1.0, 1.0), 1.0, 0.3, 1.0)
+        
+        nel = getncells(problem.ch.dh.grid)
+        @test nel == prod(nels)
+        
+        # Test with empty fixed elements
+        p_empty = get_fixed_element_projector(problem, Int[], Int[])
+        @test p_empty.nel == nel
+        @test get_free_variable_count(p_empty) == nel
+        @test all(p_empty.black .== false)
+        @test all(p_empty.white .== false)
+        
+        # Test with black cells only (first row solid)
+        black_cells = 1:nels[1]
+        p_black = get_fixed_element_projector(problem, black_cells, Int[])
+        @test p_black.nel == nel
+        @test count(p_black.black) == nels[1]
+        @test count(p_black.white) == 0
+        @test get_free_variable_count(p_black) == nel - nels[1]
+        
+        # Test with white cells only (last row void)
+        white_cells = (nel - nels[1] + 1):nel
+        p_white = get_fixed_element_projector(problem, Int[], white_cells)
+        @test p_white.nel == nel
+        @test count(p_white.black) == 0
+        @test count(p_white.white) == nels[1]
+        @test get_free_variable_count(p_white) == nel - nels[1]
+        
+        # Test with both black and white cells
+        p_both = get_fixed_element_projector(problem, black_cells, white_cells)
+        @test p_both.nel == nel
+        @test count(p_both.black) == nels[1]
+        @test count(p_both.white) == nels[1]
+        @test get_free_variable_count(p_both) == nel - 2 * nels[1]
+        
+        # Verify projector works correctly
+        x_free = fill(0.5, get_free_variable_count(p_both))
+        ρ = p_both(x_free)
+        @test length(ρ) == nel
+        @test all(ρ[black_cells] .== 1.0)
+        @test all(ρ[white_cells] .== 0.0)
+        @test all(ρ[p_both.free] .== 0.5)
+    end
+    
+    @testset "HalfMBB" begin
+        # Create a half MBB problem
+        nels = (8, 4)
+        problem = HalfMBB(Val{:Linear}, nels, (1.0, 1.0), 1.0, 0.3, 1.0)
+        
+        nel = getncells(problem.ch.dh.grid)
+        @test nel == prod(nels)
+        
+        # Fix some elements
+        black_cells = [1, 2, 3]  # First few elements solid
+        white_cells = [nel-2, nel-1, nel]  # Last few elements void
+        
+        p = get_fixed_element_projector(problem, black_cells, white_cells)
+        @test p.nel == nel
+        @test count(p.black) == 3
+        @test count(p.white) == 3
+        
+        # Verify projection
+        x_free = rand(get_free_variable_count(p))
+        ρ = p(x_free)
+        @test all(ρ[black_cells] .== 1.0)
+        @test all(ρ[white_cells] .== 0.0)
+    end
+    
+    @testset "Integration with optimization workflow" begin
+        nels = (10, 6)
+        problem = PointLoadCantilever(Val{:Linear}, nels, (1.0, 1.0), 1.0, 0.3, 1.0)
+        
+        nel = getncells(problem.ch.dh.grid)
+        
+        # Define fixed boundary regions
+        black_cells = 1:nels[1]  # Bottom row fixed solid
+        white_cells = (nel - nels[1] + 1):nel  # Top row fixed void
+        
+        # Create projector from problem
+        proj = get_fixed_element_projector(problem, black_cells, white_cells)
+        
+        # Create solver
+        solver = FEASolver(DirectSolver, problem; xmin=0.001, penalty=PowerPenalty(3.0))
+        
+        # Compliance function
+        comp = Compliance(solver)
+        
+        # Objective with projection
+        function obj(x_free)
+            ρ = proj(x_free)
+            return comp(PseudoDensities(ρ))
+        end
+        
+        # Test with initial design
+        x0 = fill(0.5, get_free_variable_count(proj))
+        
+        # Verify fixed elements are respected
+        ρ0 = proj(x0)
+        @test all(ρ0[black_cells] .== 1.0)
+        @test all(ρ0[white_cells] .== 0.0)
+        
+        # Test gradient computation
+        grad = Zygote.gradient(obj, x0)[1]
+        @test length(grad) == get_free_variable_count(proj)
+        @test all(isfinite, grad)
+        
+        # Verify compliance value
+        c0 = obj(x0)
+        @test isfinite(c0)
+        @test c0 > 0
+    end
 end
 
 @testset "ChainRulesCore rrule" begin

--- a/test/Functions/test_generate_scenarios.jl
+++ b/test/Functions/test_generate_scenarios.jl
@@ -1,0 +1,431 @@
+using Test, SparseArrays, LinearAlgebra, Random
+
+# Import the function - assuming it's exported from TopOpt
+using TopOpt: generate_scenarios
+
+@testset "generate_scenarios - Basic Functionality" begin
+
+    @testset "Output structure validation" begin
+        # Test basic output properties
+        dof = 5
+        sz = (10, 3)
+        f = 1.0
+        
+        result = generate_scenarios(dof, sz, f)
+        
+        @test result isa SparseMatrixCSC{Float64, Int}
+        @test size(result) == (10, 3)
+        @test nnz(result) == 3  # One non-zero per column
+    end
+
+    @testset "Non-zero entries at correct positions" begin
+        # Verify all non-zeros are in the specified dof row
+        dof = 3
+        sz = (8, 5)
+        f = 2.5
+        
+        result = generate_scenarios(dof, sz, f)
+        
+        # Find non-zero positions
+        rows, cols, vals = findnz(result)
+        
+        # All non-zeros should be in row 'dof'
+        @test all(rows .== dof)
+        
+        # Should have one entry per column
+        @test length(cols) == 5
+        @test sort(cols) == [1, 2, 3, 4, 5]
+    end
+
+    @testset "Base force value without perturbation" begin
+        # Test with zero perturbation to verify base values
+        dof = 2
+        sz = (6, 4)
+        f = 10.0
+        
+        # Zero perturbation
+        zero_perturb = () -> 0.0
+        result = generate_scenarios(dof, sz, f, zero_perturb)
+        
+        rows, cols, vals = findnz(result)
+        
+        # All values should equal f exactly
+        @test all(vals .== f)
+        @test length(vals) == 4
+    end
+
+    @testset "Correct dimensions for various sizes" begin
+        test_cases = [
+            (1, (5, 1)),      # Single scenario
+            (3, (10, 5)),     # Multiple scenarios
+            (7, (20, 10)),    # Larger matrix
+            (1, (1, 1)),      # Minimal case
+        ]
+        
+        for (dof, sz) in test_cases
+            result = generate_scenarios(dof, sz, 1.0)
+            @test size(result) == sz
+            @test nnz(result) == sz[2]
+        end
+    end
+end
+
+@testset "generate_scenarios - Perturbation Behavior" begin
+
+    @testset "Default perturbation produces variation" begin
+        # Default perturb is () -> (rand() - 0.5), giving range [-0.5, 0.5]
+        Random.seed!(123)
+        dof = 1
+        sz = (5, 100)  # Many scenarios to test statistical properties
+        f = 1.0
+        
+        result = generate_scenarios(dof, sz, f)
+        rows, cols, vals = findnz(result)
+        
+        # Values should vary (not all identical)
+        @test length(unique(vals)) > 1
+        
+        # All values should be positive since f > 0 and perturb > -0.5
+        @test all(vals .> 0)
+        
+        # Values should be in range [0.5*f, 1.5*f]
+        @test all(vals .>= 0.5 * f)
+        @test all(vals .<= 1.5 * f)
+    end
+
+    @testset "Custom perturbation function" begin
+        # Test with custom perturbation
+        dof = 2
+        sz = (4, 3)
+        f = 5.0
+        
+        # Fixed perturbation
+        fixed_perturb = () -> 0.2
+        result = generate_scenarios(dof, sz, f, fixed_perturb)
+        
+        rows, cols, vals = findnz(result)
+        
+        # All values should be f * (1 + 0.2) = 6.0
+        @test all(vals .== 6.0)
+    end
+
+    @testset "Negative perturbation" begin
+        # Test with negative perturbation
+        dof = 1
+        sz = (3, 2)
+        f = 10.0
+        
+        neg_perturb = () -> -0.3
+        result = generate_scenarios(dof, sz, f, neg_perturb)
+        
+        rows, cols, vals = findnz(result)
+        
+        # Values should be f * (1 - 0.3) = 7.0
+        @test all(vals .== 7.0)
+    end
+
+    @testset "Zero perturbation consistency" begin
+        # With zero perturbation, all scenarios should be identical
+        dof = 3
+        sz = (10, 5)
+        f = 2.0
+        
+        zero_perturb = () -> 0.0
+        result = generate_scenarios(dof, sz, f, zero_perturb)
+        
+        rows, cols, vals = findnz(result)
+        
+        @test all(vals .== f)
+        @test length(vals) == 5
+    end
+end
+
+@testset "generate_scenarios - Edge Cases" begin
+
+    @testset "Single scenario" begin
+        # Single column matrix
+        dof = 5
+        sz = (10, 1)
+        f = 1.0
+        
+        # Use zero perturbation for exact value check
+        zero_perturb = () -> 0.0
+        result = generate_scenarios(dof, sz, f, zero_perturb)
+        
+        @test size(result) == (10, 1)
+        @test nnz(result) == 1
+        @test result[dof, 1] ≈ f atol=1e-10
+    end
+
+    @testset "dof at boundaries" begin
+        # Test with dof at first row
+        result_first = generate_scenarios(1, (5, 3), 1.0, () -> 0.0)
+        @test result_first[1, :] ≈ [1.0, 1.0, 1.0] atol=1e-10
+        
+        # Test with dof at last row
+        result_last = generate_scenarios(5, (5, 3), 1.0, () -> 0.0)
+        @test result_last[5, :] ≈ [1.0, 1.0, 1.0] atol=1e-10
+    end
+
+    @testset "Zero force" begin
+        # Test with f = 0
+        dof = 2
+        sz = (5, 3)
+        f = 0.0
+        
+        result = generate_scenarios(dof, sz, f)
+        rows, cols, vals = findnz(result)
+        
+        # All values should be zero
+        @test all(vals .== 0.0)
+    end
+
+    @testset "Negative force" begin
+        # Test with negative f
+        dof = 2
+        sz = (5, 3)
+        f = -5.0
+        
+        zero_perturb = () -> 0.0
+        result = generate_scenarios(dof, sz, f, zero_perturb)
+        rows, cols, vals = findnz(result)
+        
+        @test all(vals .== -5.0)
+    end
+
+    @testset "Large values" begin
+        # Test with large force values
+        dof = 1
+        sz = (100, 50)
+        f = 1e6
+        
+        zero_perturb = () -> 0.0
+        result = generate_scenarios(dof, sz, f, zero_perturb)
+        
+        @test size(result) == (100, 50)
+        @test nnz(result) == 50
+        @test all(nonzeros(result) .== f)
+    end
+
+    @testset "Very small values" begin
+        # Test with very small force values
+        dof = 1
+        sz = (10, 5)
+        f = 1e-10
+        
+        zero_perturb = () -> 0.0
+        result = generate_scenarios(dof, sz, f, zero_perturb)
+        
+        rows, cols, vals = findnz(result)
+        @test all(vals .≈ f)
+    end
+end
+
+@testset "generate_scenarios - Sparse Matrix Properties" begin
+
+    @testset "Sparsity pattern" begin
+        dof = 3
+        sz = (10, 5)
+        f = 1.0
+        
+        result = generate_scenarios(dof, sz, f)
+        
+        # Verify it's properly sparse
+        @test issparse(result)
+        
+        # Check sparsity ratio
+        total_elements = prod(sz)
+        nonzero_elements = nnz(result)
+        sparsity = 1 - nonzero_elements / total_elements
+        
+        @test sparsity >= 0.9  # Should be >= 90% sparse for this structure
+    end
+
+    @testset "Column-wise structure" begin
+        # Each column should have exactly one non-zero
+        dof = 4
+        sz = (8, 6)
+        f = 2.0
+        
+        result = generate_scenarios(dof, sz, f)
+        
+        for col in 1:sz[2]
+            col_nnz = count(result[:, col] .!= 0)
+            @test col_nnz == 1
+        end
+    end
+
+    @testset "Can be converted to dense" begin
+        # Should work with dense conversion for small matrices
+        dof = 2
+        sz = (4, 3)
+        f = 1.5
+        
+        result = generate_scenarios(dof, sz, f)
+        dense_result = Matrix(result)
+        
+        @test size(dense_result) == sz
+        @test dense_result[dof, :] ≈ nonzeros(result) atol=1e-10
+        @test sum(dense_result) ≈ sum(nonzeros(result)) atol=1e-10
+    end
+end
+
+@testset "generate_scenarios - Reproducibility" begin
+
+    @testset "Fixed random seed gives reproducible results" begin
+        dof = 2
+        sz = (5, 10)
+        f = 1.0
+        
+        # First call with seed
+        Random.seed!(42)
+        result1 = generate_scenarios(dof, sz, f)
+        
+        # Second call with same seed
+        Random.seed!(42)
+        result2 = generate_scenarios(dof, sz, f)
+        
+        rows1, cols1, vals1 = findnz(result1)
+        rows2, cols2, vals2 = findnz(result2)
+        
+        @test vals1 ≈ vals2 atol=1e-10
+    end
+
+    @testset "Different seeds give different results" begin
+        dof = 2
+        sz = (5, 100)
+        f = 1.0
+        
+        # First call with seed 1
+        Random.seed!(1)
+        result1 = generate_scenarios(dof, sz, f)
+        
+        # Second call with seed 2
+        Random.seed!(2)
+        result2 = generate_scenarios(dof, sz, f)
+        
+        rows1, cols1, vals1 = findnz(result1)
+        rows2, cols2, vals2 = findnz(result2)
+        
+        # Values should be different (statistically unlikely to be identical)
+        @test vals1 != vals2
+    end
+end
+
+@testset "generate_scenarios - Mathematical Properties" begin
+
+    @testset "Sum of values" begin
+        # Test that sum of values equals expected value
+        dof = 1
+        sz = (3, 5)
+        f = 2.0
+        
+        zero_perturb = () -> 0.0
+        result = generate_scenarios(dof, sz, f, zero_perturb)
+        
+        # Sum should be nscenarios * f
+        @test sum(result) ≈ sz[2] * f atol=1e-10
+    end
+
+    @testset "Frobenius norm" begin
+        # Test Frobenius norm
+        dof = 2
+        sz = (5, 4)
+        f = 3.0
+        
+        zero_perturb = () -> 0.0
+        result = generate_scenarios(dof, sz, f, zero_perturb)
+        
+        # Frobenius norm should be sqrt(nscenarios * f^2)
+        expected_norm = sqrt(sz[2] * f^2)
+        @test norm(result) ≈ expected_norm atol=1e-10
+    end
+
+    @testset "Transpose properties" begin
+        dof = 3
+        sz = (6, 4)
+        f = 2.0
+        
+        zero_perturb = () -> 0.0
+        result = generate_scenarios(dof, sz, f, zero_perturb)
+        result_t = transpose(result)
+        
+        # Transpose should have non-zeros in column 'dof'
+        @test nnz(result_t) == sz[2]
+        @test all(result_t[:, dof] .== f)
+    end
+end
+
+@testset "generate_scenarios - Integration Tests" begin
+
+    @testset "Works with LinearAlgebra operations" begin
+        dof = 2
+        sz = (5, 3)
+        f = 2.0
+        
+        zero_perturb = () -> 0.0
+        F = generate_scenarios(dof, sz, f, zero_perturb)
+        
+        # Should work with matrix multiplication
+        v = ones(3)
+        result = F * v
+        
+        @test length(result) == 5
+        @test result[dof] ≈ 3 * f atol=1e-10
+        
+        # Other entries should be zero
+        for i in setdiff(1:5, dof)
+            @test result[i] ≈ 0.0 atol=1e-10
+        end
+    end
+
+    @testset "Can be used in sparse matrix arithmetic" begin
+        dof = 1
+        sz = (4, 2)
+        f = 1.0
+        
+        zero_perturb = () -> 0.0
+        F1 = generate_scenarios(dof, sz, f, zero_perturb)
+        F2 = generate_scenarios(2, sz, 2.0, zero_perturb)
+        
+        # Addition
+        F_sum = F1 + F2
+        @test nnz(F_sum) == 4  # Two non-zeros per column
+        
+        # Scalar multiplication
+        F_scaled = 3.0 * F1
+        @test all(nonzeros(F_scaled) .≈ 3.0)
+    end
+end
+
+@testset "generate_scenarios - Type Stability" begin
+
+    @testset "Returns correct types" begin
+        dof = 1
+        sz = (3, 2)
+        f = 1.0
+        
+        result = generate_scenarios(dof, sz, f)
+        
+        @test eltype(result) == Float64
+        @test result isa SparseMatrixCSC{Float64, Int}
+    end
+
+    @testset "Works with different force types" begin
+        dof = 1
+        sz = (3, 2)
+        
+        # Float32 force
+        f32 = Float32(1.0)
+        result_f32 = generate_scenarios(dof, sz, f32)
+        
+        # Int force
+        f_int = 5
+        result_int = generate_scenarios(dof, sz, f_int)
+        
+        @test eltype(result_f32) == Float64  # Should convert to Float64
+        @test eltype(result_int) == Float64
+    end
+end
+
+println("All generate_scenarios tests completed!")

--- a/test/Functions/test_getdim.jl
+++ b/test/Functions/test_getdim.jl
@@ -1,0 +1,39 @@
+using TopOpt, Nonconvex, Test
+using Nonconvex: NonconvexCore, getdim
+
+# Minimal test for Nonconvex.NonconvexCore.getdim(::Compliance) = 1
+@testset "getdim Compliance test" begin
+    nels = (2, 2)
+    problem = HalfMBB(Val{:Linear}, nels, (1.0, 1.0), 1.0, 0.3, 1.0)
+    solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(3.0))
+    
+    comp = Compliance(solver)
+    
+    # Test Nonconvex.NonconvexCore.getdim(::Compliance) = 1
+    dim = Nonconvex.NonconvexCore.getdim(comp)
+    @test dim == 1
+    println("✓ Nonconvex.NonconvexCore.getdim(::Compliance) = $dim")
+    
+    # Also test that getdim returns 1 for Volume
+    vol = Volume(solver)
+    vol_dim = getdim(vol)
+    @test vol_dim == 1
+    println("✓ getdim(::Volume) = $vol_dim")
+end
+
+# Test for Nonconvex.NonconvexCore.getdim(::MeanCompliance) = 1
+@testset "getdim MeanCompliance test" begin
+    nels = (2, 2)
+    problem = HalfMBB(Val{:Linear}, nels, (1.0, 1.0), 1.0, 0.3, 1.0)
+    multiload_problem = MultiLoad(problem, F -> begin
+        return [F[:, 1] F[:, 1]]
+    end)
+    solver = FEASolver(DirectSolver, multiload_problem; xmin=0.01, penalty=PowerPenalty(3.0))
+    
+    mean_comp = MeanCompliance(multiload_problem, solver; method=:exact)
+    
+    # Test Nonconvex.NonconvexCore.getdim(::MeanCompliance) = 1
+    dim = Nonconvex.NonconvexCore.getdim(mean_comp)
+    @test dim == 1
+    println("✓ Nonconvex.NonconvexCore.getdim(::MeanCompliance) = $dim")
+end

--- a/test/Functions/test_hadamard.jl
+++ b/test/Functions/test_hadamard.jl
@@ -1,0 +1,168 @@
+# Test file for hadamard functions
+using Test
+using LinearAlgebra
+using TopOpt
+
+# Import the hadamard functions from TopOpt.Functions
+# hadamard! is exported from TopOpt, but hadamard2! and hadamard3! are internal
+import TopOpt: hadamard!
+using TopOpt.Functions: hadamard2!, hadamard3!
+
+@testset "hadamard3! tests" begin
+    @testset "Basic functionality" begin
+        # Test 2x2 matrix (power of 2)
+        V = zeros(2, 2)
+        hadamard3!(V)
+        @test V == [1 1; 1 -1]
+        
+        # Test 4x4 matrix
+        V = zeros(4, 4)
+        hadamard3!(V)
+        @test V == [1 1 1 1; 1 -1 1 -1; 1 1 -1 -1; 1 -1 -1 1]
+    end
+    
+    @testset "Rectangular matrices" begin
+        # More rows than columns
+        V = zeros(6, 4)
+        hadamard3!(V)
+        @test size(V) == (6, 4)
+        # Check all values are ±1
+        @test all(x -> x == 1 || x == -1, V)
+        
+        # Fewer columns than rows (n < nv case)
+        V = zeros(4, 2)
+        hadamard3!(V)
+        @test size(V) == (4, 2)
+        @test all(x -> x == 1 || x == -1, V)
+    end
+    
+    @testset "Non-power-of-2 dimensions" begin
+        V = zeros(3, 3)
+        hadamard3!(V)
+        @test size(V) == (3, 3)
+        @test all(x -> x == 1 || x == -1, V)
+        
+        V = zeros(5, 6)
+        hadamard3!(V)
+        @test size(V) == (5, 6)
+        @test all(x -> x == 1 || x == -1, V)
+    end
+    
+    @testset "Edge cases" begin
+        # 1x1 matrix
+        V = zeros(1, 1)
+        hadamard3!(V)
+        @test V ≈ [1.0]
+        
+        # Single row
+        V = zeros(1, 4)
+        hadamard3!(V)
+        @test size(V) == (1, 4)
+        @test all(x -> x == 1 || x == -1, V)
+        
+        # Single column
+        V = zeros(4, 1)
+        hadamard3!(V)
+        @test size(V) == (4, 1)
+        @test all(x -> x == 1 || x == -1, V)
+    end
+end
+
+@testset "hadamard2! tests" begin
+    @testset "Basic functionality" begin
+        # Test 2x2 matrix
+        V = zeros(2, 2)
+        hadamard2!(V)
+        @test V == [1 1; 1 -1]
+        
+        # Test 4x4 matrix
+        V = zeros(4, 4)
+        hadamard2!(V)
+        expected = [1 1 1 1; 
+                    1 -1 1 -1; 
+                    1 1 -1 -1; 
+                    1 -1 -1 1]
+        @test V == expected
+    end
+    
+    @testset "Rectangular matrices" begin
+        # More rows than columns
+        V = zeros(6, 4)
+        hadamard2!(V)
+        @test size(V) == (6, 4)
+        @test all(x -> x == 1 || x == -1, V)
+        
+        # More rows (should just repeat rows with sign flip)
+        V = zeros(8, 4)
+        hadamard2!(V)
+        @test size(V) == (8, 4)
+        @test all(x -> x == 1 || x == -1, V)
+    end
+    
+    @testset "Edge cases" begin
+        # 1x1 matrix
+        V = zeros(1, 1)
+        hadamard2!(V)
+        @test V ≈ [1.0]
+        
+        # Single row
+        V = zeros(1, 4)
+        hadamard2!(V)
+        @test size(V) == (1, 4)
+        @test all(x -> x == 1 || x == -1, V)
+        
+        # Single column
+        V = zeros(4, 1)
+        hadamard2!(V)
+        @test size(V) == (4, 1)
+        @test all(x -> x == 1 || x == -1, V)
+    end
+end
+
+@testset "Comparison between hadamard! variants" begin
+    @testset "Square power-of-2 matrices" begin
+        # For square power-of-2 matrices, all should produce same result
+        for n in [1, 2, 4, 8]
+            V1 = zeros(n, n)
+            V2 = zeros(n, n)
+            V3 = zeros(n, n)
+            hadamard!(V1)
+            hadamard2!(V2)
+            hadamard3!(V3)
+            
+            # Check they all produce valid Hadamard matrices
+            @test all(x -> x == 1 || x == -1, V1)
+            @test all(x -> x == 1 || x == -1, V2)
+            @test all(x -> x == 1 || x == -1, V3)
+        end
+    end
+    
+    @testset "In-place modification" begin
+        # Test that functions modify V in-place
+        V1 = zeros(4, 4)
+        V2 = copy(V1)
+        result = hadamard3!(V1)
+        @test result === V1  # Should return the same object
+        @test V1 != V2      # Should have been modified
+    end
+end
+
+@testset "Hadamard matrix properties" begin
+    @testset "Orthogonality (for square matrices)" begin
+        for n in [1, 2, 4, 8]
+            V = zeros(n, n)
+            hadamard3!(V)
+            # For a proper Hadamard matrix: H*H' = n*I
+            @test isapprox(V * V', n * I, atol=1e-10)
+        end
+    end
+    
+    @testset "Determinant (for power-of-2)" begin
+        for n in [1, 2, 4, 8]
+            V = zeros(n, n)
+            hadamard3!(V)
+            # det(Hadamard) = ±n^(n/2)
+            @test abs(det(V)) ≈ n^(n/2)
+        end
+    end
+end

--- a/test/Functions/test_mean_compliance_branches.jl
+++ b/test/Functions/test_mean_compliance_branches.jl
@@ -1,0 +1,262 @@
+using TopOpt, Test, LinearAlgebra, Random, SparseArrays
+using TopOpt: Nonconvex
+using Statistics: mean
+
+# Test the conditional branches in MeanCompliance constructor
+# These tests specifically target the branching logic in lines ~18-43 of mean_compliance.jl
+
+Random.seed!(42)
+
+@testset "MeanCompliance Constructor Branches" begin
+
+    # Common test setup
+    E = 1.0
+    ν = 0.3
+    force = 1.0
+    nels = (6, 4)
+
+    base_problem = PointLoadCantilever(Val{:Linear}, nels, (1.0, 1.0), E, ν, force)
+
+    nloads = 3
+    F = spzeros(TopOpt.Ferrite.ndofs(base_problem.ch.dh), nloads)
+    dense_load_inds = vec(TopOpt.TopOptProblems.get_surface_dofs(base_problem))
+    for i in 1:nloads
+        dofs = dense_load_inds[rand(1:length(dense_load_inds), 2)]
+        F[dofs, i] .= randn(2)
+    end
+
+    problem = MultiLoad(base_problem, F)
+
+    @testset "Branch 1: method=:trace creates TraceEstimationMean" begin
+        solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+
+        # Test with default parameters
+        mc = MeanCompliance(problem, solver; method=:trace)
+        @test mc.method isa TopOpt.Functions.TraceEstimationMean
+
+        # Test with nv specified
+        mc = MeanCompliance(problem, solver; method=:trace, nv=5)
+        @test mc.method isa TopOpt.Functions.TraceEstimationMean
+        @test size(mc.method.V, 2) == 5
+
+        # Test with sample_method=:hadamard
+        mc = MeanCompliance(problem, solver; method=:trace, nv=5, sample_method=:hadamard)
+        @test mc.method isa TopOpt.Functions.TraceEstimationMean
+        @test mc.method.sample_once == true  # hadamard forces sample_once=true
+
+        # Test with sample_method=:hutch (default behavior)
+        mc = MeanCompliance(problem, solver; method=:trace, nv=5, sample_method=:hutch)
+        @test mc.method isa TopOpt.Functions.TraceEstimationMean
+    end
+
+    @testset "Branch 2: method=:approx creates TraceEstimationMean" begin
+        solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+
+        # Test with default parameters
+        mc = MeanCompliance(problem, solver; method=:approx)
+        @test mc.method isa TopOpt.Functions.TraceEstimationMean
+
+        # Test with nv specified
+        mc = MeanCompliance(problem, solver; method=:approx, nv=7)
+        @test mc.method isa TopOpt.Functions.TraceEstimationMean
+        @test size(mc.method.V, 2) == 7
+    end
+
+    @testset "Branch 3: method=:svd_trace creates TraceEstimationSVDMean" begin
+        solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+
+        # Test with default parameters
+        mc = MeanCompliance(problem, solver; method=:svd_trace)
+        @test mc.method isa TopOpt.Functions.TraceEstimationSVDMean
+
+        # Test with nv specified
+        mc = MeanCompliance(problem, solver; method=:svd_trace, nv=4)
+        @test mc.method isa TopOpt.Functions.TraceEstimationSVDMean
+        @test size(mc.method.V, 2) == 4
+
+        # Test with sample_method=:hadamard
+        mc = MeanCompliance(problem, solver; method=:svd_trace, nv=4, sample_method=:hadamard)
+        @test mc.method isa TopOpt.Functions.TraceEstimationSVDMean
+        @test mc.method.sample_once == true  # hadamard forces sample_once=true
+
+        # Test with sample_method=:hutch
+        mc = MeanCompliance(problem, solver; method=:svd_trace, nv=4, sample_method=:hutch)
+        @test mc.method isa TopOpt.Functions.TraceEstimationSVDMean
+    end
+
+    @testset "V matrix parameter handling - TraceEstimationMean" begin
+        solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+
+        # Test V === nothing with nv === nothing (default nv=1)
+        mc = MeanCompliance(problem, solver; method=:trace)
+        @test mc.method isa TopOpt.Functions.TraceEstimationMean
+        @test size(mc.method.V, 2) == 1
+
+        # Test V === nothing with nv specified
+        mc = MeanCompliance(problem, solver; method=:trace, nv=10)
+        @test mc.method isa TopOpt.Functions.TraceEstimationMean
+        @test size(mc.method.V, 2) == 10
+
+        # Test V provided with nv === nothing (use size(V, 2))
+        V_provided = zeros(Float64, size(F, 2), 8)
+        mc = MeanCompliance(problem, solver; method=:trace, V=V_provided)
+        @test mc.method isa TopOpt.Functions.TraceEstimationMean
+        @test size(mc.method.V, 2) == 8
+
+        # Test V provided with nv specified (take first nv columns)
+        V_provided = zeros(Float64, size(F, 2), 15)
+        mc = MeanCompliance(problem, solver; method=:trace, V=V_provided, nv=5)
+        @test mc.method isa TopOpt.Functions.TraceEstimationMean
+        @test size(mc.method.V, 2) == 5
+    end
+
+    @testset "V matrix parameter handling - TraceEstimationSVDMean" begin
+        solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+
+        # Test V === nothing with nv === nothing (default nv=1)
+        mc = MeanCompliance(problem, solver; method=:svd_trace)
+        @test mc.method isa TopOpt.Functions.TraceEstimationSVDMean
+        @test size(mc.method.V, 2) == 1
+
+        # Test V === nothing with nv specified
+        mc = MeanCompliance(problem, solver; method=:svd_trace, nv=10)
+        @test mc.method isa TopOpt.Functions.TraceEstimationSVDMean
+        @test size(mc.method.V, 2) == 10
+
+        # Test V provided with nv === nothing (use size(V, 2))
+        # Note: V must match US dimensions, not F dimensions
+        # Get US from ExactSVDMean to determine correct size
+        exact_svd = TopOpt.Functions.ExactSVDMean(F)
+        nv_us = size(exact_svd.US, 2)
+        V_provided = zeros(Float64, nv_us, 8)
+        mc = MeanCompliance(problem, solver; method=:svd_trace, V=V_provided)
+        @test mc.method isa TopOpt.Functions.TraceEstimationSVDMean
+        @test size(mc.method.V, 2) == 8
+
+        # Test V provided with nv specified (take first nv columns)
+        V_provided = zeros(Float64, nv_us, 12)
+        mc = MeanCompliance(problem, solver; method=:svd_trace, V=V_provided, nv=6)
+        @test mc.method isa TopOpt.Functions.TraceEstimationSVDMean
+        @test size(mc.method.V, 2) == 6
+    end
+
+    @testset "sample_method symbol conversion" begin
+        solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+
+        # Test hadamard symbol conversion for TraceEstimationMean
+        mc = MeanCompliance(problem, solver; method=:trace, nv=3, sample_method=:hadamard)
+        @test mc.method.sample_method === TopOpt.Functions.hadamard!
+
+        # Test hutch symbol conversion for TraceEstimationMean
+        mc = MeanCompliance(problem, solver; method=:trace, nv=3, sample_method=:hutch)
+        @test mc.method.sample_method === TopOpt.Functions.hutch_rand!
+
+        # Test hadamard symbol conversion for TraceEstimationSVDMean
+        mc = MeanCompliance(problem, solver; method=:svd_trace, nv=3, sample_method=:hadamard)
+        @test mc.method.sample_method === TopOpt.Functions.hadamard!
+
+        # Test hutch symbol conversion for TraceEstimationSVDMean
+        mc = MeanCompliance(problem, solver; method=:svd_trace, nv=3, sample_method=:hutch)
+        @test mc.method.sample_method === TopOpt.Functions.hutch_rand!
+    end
+
+    @testset "sample_once parameter handling" begin
+        solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+
+        # Test sample_once=true for TraceEstimationMean
+        mc = MeanCompliance(problem, solver; method=:trace, nv=3, sample_once=true)
+        @test mc.method.sample_once == true
+
+        # Test sample_once=false for TraceEstimationMean
+        mc = MeanCompliance(problem, solver; method=:trace, nv=3, sample_once=false)
+        @test mc.method.sample_once == false
+
+        # Test sample_once=true for TraceEstimationSVDMean
+        mc = MeanCompliance(problem, solver; method=:svd_trace, nv=3, sample_once=true)
+        @test mc.method.sample_once == true
+
+        # Test sample_once=false for TraceEstimationSVDMean
+        mc = MeanCompliance(problem, solver; method=:svd_trace, nv=3, sample_once=false)
+        @test mc.method.sample_once == false
+
+        # Test that hadamard forces sample_once=true for TraceEstimationSVDMean
+        mc = MeanCompliance(problem, solver; method=:svd_trace, nv=3, sample_method=:hadamard, sample_once=false)
+        @test mc.method.sample_once == true
+    end
+
+    @testset "Both branches produce valid function values" begin
+        # Verify that both branches produce valid, positive compliance values
+        x = fill(0.5, nels[1] * nels[2])
+
+        # Test TraceEstimationMean
+        solver_trace = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+        mc_trace = MeanCompliance(problem, solver_trace; method=:trace, nv=10)
+        val_trace = mc_trace(PseudoDensities(x))
+        @test val_trace > 0
+        @test isfinite(val_trace)
+
+        # Test TraceEstimationSVDMean
+        solver_svd = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+        mc_svd = MeanCompliance(problem, solver_svd; method=:svd_trace, nv=10)
+        val_svd = mc_svd(PseudoDensities(x))
+        @test val_svd > 0
+        @test isfinite(val_svd)
+    end
+
+    @testset "Both branches produce consistent gradients" begin
+        x = fill(0.5, nels[1] * nels[2])
+
+        # Test TraceEstimationMean gradient
+        solver_trace = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+        mc_trace = MeanCompliance(problem, solver_trace; method=:trace, nv=10)
+        grad_trace = Zygote.gradient(x -> mc_trace(PseudoDensities(x)), x)[1]
+        @test length(grad_trace) == length(x)
+        @test all(isfinite.(grad_trace))
+        @test mean(grad_trace) < 0  # Gradient should be negative (more material = lower compliance)
+
+        # Test TraceEstimationSVDMean gradient
+        solver_svd = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+        mc_svd = MeanCompliance(problem, solver_svd; method=:svd_trace, nv=10)
+        grad_svd = Zygote.gradient(x -> mc_svd(PseudoDensities(x)), x)[1]
+        @test length(grad_svd) == length(x)
+        @test all(isfinite.(grad_svd))
+        @test mean(grad_svd) < 0
+    end
+
+    @testset "Code duplication verification - both branches have identical V handling" begin
+        # This test verifies that the duplicated code in both branches
+        # produces identical results for equivalent inputs
+
+        # Test case 1: V === nothing, nv === nothing
+        solver1 = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+        mc_trace1 = MeanCompliance(problem, solver1; method=:trace)
+        mc_svd1 = MeanCompliance(problem, solver1; method=:svd_trace)
+        @test size(mc_trace1.method.V, 2) == size(mc_svd1.method.V, 2) == 1
+
+        # Test case 2: V === nothing, nv=5
+        solver2 = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+        mc_trace2 = MeanCompliance(problem, solver2; method=:trace, nv=5)
+        mc_svd2 = MeanCompliance(problem, solver2; method=:svd_trace, nv=5)
+        @test size(mc_trace2.method.V, 2) == size(mc_svd2.method.V, 2) == 5
+
+        # Test case 3: V provided with nv === nothing
+        exact_svd = TopOpt.Functions.ExactSVDMean(F)
+        nv_us = size(exact_svd.US, 2)
+        V_trace = zeros(Float64, size(F, 2), 6)
+        V_svd = zeros(Float64, nv_us, 6)
+
+        solver3 = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+        mc_trace3 = MeanCompliance(problem, solver3; method=:trace, V=V_trace)
+        mc_svd3 = MeanCompliance(problem, solver3; method=:svd_trace, V=V_svd)
+        @test size(mc_trace3.method.V, 2) == size(mc_svd3.method.V, 2) == 6
+
+        # Test case 4: V provided with nv specified
+        V_trace = zeros(Float64, size(F, 2), 10)
+        V_svd = zeros(Float64, nv_us, 10)
+
+        solver4 = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(2.0))
+        mc_trace4 = MeanCompliance(problem, solver4; method=:trace, V=V_trace, nv=4)
+        mc_svd4 = MeanCompliance(problem, solver4; method=:svd_trace, V=V_svd, nv=4)
+        @test size(mc_trace4.method.V, 2) == size(mc_svd4.method.V, 2) == 4
+    end
+end

--- a/test/Functions/test_stress_tensor_rrule.jl
+++ b/test/Functions/test_stress_tensor_rrule.jl
@@ -1,0 +1,323 @@
+using TopOpt,
+    Zygote, FiniteDifferences, LinearAlgebra, Test, Random, SparseArrays, ForwardDiff, ChainRulesCore, Ferrite
+const FDM = FiniteDifferences
+using TopOpt: ndofs
+using Ferrite: ndofs_per_cell, getncells
+using NonconvexCore: getdim
+using TopOpt.Functions: StressTensor, DisplacementResult, reinit!
+
+Random.seed!(1)
+
+@testset "StressTensor reinit! rrule" begin
+    nels = (2, 2)
+    problem = HalfMBB(Val{:Linear}, nels, (1.0, 1.0), 1.0, 0.3, 1.0)
+    solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(3.0))
+    
+    st = StressTensor(solver)
+    dp = Displacement(solver)
+    
+    # Get displacement result for testing
+    x = clamp.(rand(prod(nels)), 0.1, 1.0)
+    u = dp(PseudoDensities(x))
+    
+    @testset "rrule returns correct types" begin
+        # Test rrule for StressTensor reinit!
+        cellidx = 1
+        y, pullback = ChainRulesCore.rrule(reinit!, st, cellidx)
+        
+        # Check that the output is the StressTensor itself
+        @test y === st
+        
+        # Check that the pullback returns NoTangent for all inputs
+        Δy = ChainRulesCore.NoTangent()
+        grads = pullback(Δy)
+        
+        @test length(grads) == 3
+        @test grads[1] isa ChainRulesCore.NoTangent
+        @test grads[2] isa ChainRulesCore.NoTangent
+        @test grads[3] isa ChainRulesCore.NoTangent
+    end
+    
+    @testset "rrule for different cell indices" begin
+        for cellidx in 1:length(st.cells)
+            y, pullback = ChainRulesCore.rrule(reinit!, st, cellidx)
+            
+            @test y === st
+            
+            # Test pullback with different tangents
+            Δy = ChainRulesCore.NoTangent()
+            grads = pullback(Δy)
+            
+            @test all(g isa ChainRulesCore.NoTangent for g in grads)
+        end
+    end
+    
+    @testset "rrule with Float64 tangent" begin
+        cellidx = 1
+        y, pullback = ChainRulesCore.rrule(reinit!, st, cellidx)
+        
+        # Test with a Float64 tangent (should still return NoTangent)
+        Δy = 0.0
+        grads = pullback(Δy)
+        
+        @test length(grads) == 3
+        @test grads[1] isa ChainRulesCore.NoTangent
+        @test grads[2] isa ChainRulesCore.NoTangent
+        @test grads[3] isa ChainRulesCore.NoTangent
+    end
+    
+    @testset "rrule works with Zygote" begin
+        # Test that Zygote can use the rrule correctly
+        # by computing gradients through the stress tensor computation
+        
+        # Define a function that uses reinit! internally
+        function test_fn(st, u, cellidx)
+            reinit!(st, cellidx)
+            # Return some scalar value based on the stress tensor
+            return sum(st.global_dofs)
+        end
+        
+        # Test that Zygote can differentiate through this
+        # The rrule should prevent Zygote from trying to AD through reinit!
+        cellidx = 1
+        val = test_fn(st, u, cellidx)
+        @test isa(val, Int)
+        @test val > 0
+        
+        # The rrule is a no-op for gradients, so any gradient computation
+        # that involves reinit! should work without error
+    end
+    
+    @testset "rrule consistency with ElementStressTensor" begin
+        # Also test ElementStressTensor rrule for consistency
+        est = st[1]
+        
+        cellidx = 1
+        y, pullback = ChainRulesCore.rrule(reinit!, est, cellidx)
+        
+        @test y === est
+        
+        Δy = ChainRulesCore.NoTangent()
+        grads = pullback(Δy)
+        
+        @test length(grads) == 3
+        @test all(g isa ChainRulesCore.NoTangent for g in grads)
+    end
+    
+    @testset "reinit! modifies StressTensor correctly" begin
+        # Save original state
+        orig_dofs = copy(st.global_dofs)
+        
+        cellidx = 2
+        reinit!(st, cellidx)
+        
+        # global_dofs should be modified
+        @test st.global_dofs != orig_dofs
+        
+        # Now test rrule returns the modified tensor
+        cellidx = 1
+        y, _ = ChainRulesCore.rrule(reinit!, st, cellidx)
+        
+        @test y === st
+        @test y.global_dofs == st.global_dofs
+    end
+end
+
+@testset "StressTensor reinit! integration with AD" begin
+    nels = (3, 3)
+    problem = HalfMBB(Val{:Linear}, nels, (1.0, 1.0), 1.0, 0.3, 1.0)
+    solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(3.0))
+    
+    st = StressTensor(solver)
+    dp = Displacement(solver)
+    
+    @testset "AD through stress tensor computation" begin
+        # Test that we can compute gradients of stress-related quantities
+        # The rrule for reinit! allows Zygote to skip the mutation in reinit!
+        
+        for cellidx in 1:min(4, length(st.cells))
+            # Get element stress tensor
+            est = st[cellidx]
+            
+            # Define a scalar function for gradient testing
+            f = x -> begin
+                u = dp(PseudoDensities(x))
+                result = est(u)
+                return sum(abs2, result)
+            end
+            
+            x = clamp.(rand(prod(nels)), 0.1, 1.0)
+            
+            # This should work without errors thanks to the rrule
+            val = f(x)
+            @test isa(val, Real)
+            @test isfinite(val)
+            
+            # Test gradient computation
+            grad = Zygote.gradient(f, x)[1]
+            @test length(grad) == length(x)
+            @test all(isfinite, grad)
+        end
+    end
+end
+
+@testset "ElementStressTensorKernel rrule" begin
+    nels = (2, 2)
+    problem = HalfMBB(Val{:Linear}, nels, (1.0, 1.0), 1.0, 0.3, 1.0)
+    solver = FEASolver(DirectSolver, problem; xmin=0.01, penalty=PowerPenalty(3.0))
+    
+    st = StressTensor(solver)
+    dp = Displacement(solver)
+    
+    # Get displacement result for testing
+    x = clamp.(rand(prod(nels)), 0.1, 1.0)
+    u = dp(PseudoDensities(x))
+    
+    # Create an ElementStressTensorKernel
+    est = st[1]
+    reinit!(est, 1)
+    
+    # Get tensor_kernel to create ElementStressTensorKernel
+    # Access the internal structure to get the kernel
+    # tensor_kernel is called in _element_stress_tensor for each quad point and basis function
+    cellvalues = st.cellvalues
+    n_basefuncs = Ferrite.getnbasefunctions(cellvalues)
+    n_quad = Ferrite.getnquadpoints(cellvalues)
+    dim = TopOptProblems.getdim(problem)
+    
+    # Create an ElementStressTensorKernel manually (similar to tensor_kernel function)
+    kernel = TopOpt.Functions.ElementStressTensorKernel(
+        problem.E,
+        problem.ν,
+        1,  # q_point
+        1,  # basis function a
+        cellvalues,
+        dim
+    )
+    
+    @testset "rrule output types and shapes" begin
+        # Get element dofs for the kernel
+        # Kernel uses only displacement from ONE basis function (2 elements for 2D)
+        element_dofs = u.u[copy(st.global_dofs)]
+        u_single = element_dofs[dim * (kernel.a - 1) .+ (1:dim)]
+        u_element = DisplacementResult(u_single)
+        
+        # Apply the rrule
+        v, pullback = ChainRulesCore.rrule(kernel, u_element)
+        
+        # Check output type
+        @test v isa Matrix
+        @test size(v) == (dim, dim)
+        
+        # Test pullback with a random tangent
+        Δ = randn(dim, dim)
+        grads = pullback(Δ)
+        
+        # Should return (NoTangent(), Tangent)
+        @test length(grads) == 2
+        @test grads[1] isa ChainRulesCore.NoTangent
+        @test grads[2] isa ChainRulesCore.Tangent{<:DisplacementResult}
+    end
+    
+    @testset "rrule gradient correctness with finite differences" begin
+        # The kernel computes stress contribution from ONE basis function
+        # So we need displacement for just that basis function (2 elements for 2D)
+        element_dofs = u.u[copy(st.global_dofs)]
+        u_single_basis = element_dofs[dim * (kernel.a - 1) .+ (1:dim)]
+        u_element = DisplacementResult(u_single_basis)
+        
+        # Compute rrule output
+        v, pullback = ChainRulesCore.rrule(kernel, u_element)
+        
+        # Test with different tangents
+        for _ in 1:5
+            Δ = randn(dim, dim)
+            grads = pullback(Δ)
+            
+            # The gradient should be a vector matching the displacement size (2 for 2D)
+            @test size(grads[2].u) == size(u_single_basis)
+            @test all(isfinite, grads[2].u)
+        end
+        
+        # Compare with finite differences for a specific direction
+        Δ_test = randn(dim, dim)
+        
+        # Define scalar function for FD: sum(kernel output .* Δ_test)
+        f_scalar = u_vec -> sum(kernel(DisplacementResult(collect(u_vec))) .* Δ_test)
+        
+        # Compute gradient using finite differences
+        fd_grad = FiniteDifferences.grad(FDM.central_fdm(5, 1), f_scalar, u_single_basis)[1]
+        
+        # Compute gradient using rrule
+        _, pullback_fd = ChainRulesCore.rrule(kernel, u_element)
+        rrule_grad = pullback_fd(Δ_test)[2].u
+        
+        @test fd_grad ≈ rrule_grad rtol = 1e-4
+    end
+    
+    @testset "rrule for different quad points and basis functions" begin
+        element_dofs = u.u[copy(st.global_dofs)]
+        
+        # Test different combinations of quad points and basis functions
+        for q_point in 1:min(2, n_quad)
+            for a in 1:min(2, n_basefuncs)
+                kernel_test = TopOpt.Functions.ElementStressTensorKernel(
+                    problem.E,
+                    problem.ν,
+                    q_point,
+                    a,
+                    cellvalues,
+                    dim
+                )
+                
+                # Kernel uses only displacement from one basis function
+                u_single = element_dofs[dim * (a - 1) .+ (1:dim)]
+                u_element = DisplacementResult(u_single)
+                
+                v, pullback = ChainRulesCore.rrule(kernel_test, u_element)
+                
+                @test size(v) == (dim, dim)
+                @test all(isfinite, v)
+                
+                # Test pullback
+                Δ = randn(dim, dim)
+                grads = pullback(Δ)
+                
+                @test grads[1] isa ChainRulesCore.NoTangent
+                @test grads[2] isa ChainRulesCore.Tangent{<:DisplacementResult}
+                @test size(grads[2].u) == size(u_single)
+            end
+        end
+    end
+    
+    @testset "rrule consistency with ForwardDiff jacobian" begin
+        # Kernel uses displacement from one basis function only
+        element_dofs = u.u[copy(st.global_dofs)]
+        u_single = element_dofs[dim * (kernel.a - 1) .+ (1:dim)]
+        u_element = DisplacementResult(u_single)
+        
+        # Compute output and gradient using rrule
+        v_rrule, pullback = ChainRulesCore.rrule(kernel, u_element)
+        
+        # Compute output using direct call
+        v_direct = kernel(u_element)
+        
+        @test v_rrule ≈ v_direct
+        
+        # Test pullback for each output component
+        for i in 1:dim, j in 1:dim
+            Δ = zeros(dim, dim)
+            Δ[i, j] = 1.0
+            
+            grads = pullback(Δ)
+            rrule_grad = grads[2].u
+            
+            # Compare with finite differences
+            f_ij = u_vec -> kernel(DisplacementResult(collect(u_vec)))[i, j]
+            fd_result = FiniteDifferences.grad(FDM.central_fdm(5, 1), f_ij, u_single)
+            fd_grad = fd_result[1]
+            
+            @test fd_grad ≈ rrule_grad rtol = 1e-4
+        end
+    end
+end

--- a/test/Utilities/test_penalties.jl
+++ b/test/Utilities/test_penalties.jl
@@ -65,6 +65,45 @@ end
     @test_throws ArgumentError setpenalty!(solver, [1.0, 2.0, 3.0])
 end
 
+@testset "setpenalty! on Compliance object" begin
+    # Create a minimal problem and solver
+    nels = (2, 2)
+    sizes = (1.0, 1.0)
+    E = 1.0
+    ν = 0.3
+    force = 1.0
+
+    problem = PointLoadCantilever(Val{:Linear}, nels, sizes, E, ν, force)
+
+    # Create a solver using FEASolver with DirectSolver
+    solver = FEASolver(DirectSolver, problem)
+    
+    # Create a Compliance object with the solver
+    comp = Compliance(solver)
+
+    # Test initial penalty value
+    initial_penalty = getpenalty(comp)
+    @test initial_penalty isa PowerPenalty
+    @test initial_penalty.p == 1.0  # Default penalty value
+    
+    # Store the initial penalty value for comparison
+    initial_p = initial_penalty.p
+
+    # Test setpenalty! on Compliance object with a new penalty value
+    new_p = 3.0
+    setpenalty!(comp, new_p)
+    
+    # Verify the penalty was updated on the Compliance
+    updated_penalty = getpenalty(comp)
+    @test updated_penalty.p == new_p
+    
+    # Verify the penalty was also updated on the underlying solver
+    @test getpenalty(solver).p == new_p
+    
+    # Verify prev_penalty on solver stores the old value
+    @test getprevpenalty(solver).p == initial_p
+end
+
 @testset "RationalPenalty" begin
     # Test construction
     rp = RationalPenalty(3.0)
@@ -259,6 +298,311 @@ end
     f(x) = ProjectedPenalty(PowerPenalty(2.0), HeavisideProjection(3.0))(x)
     g = Zygote.gradient(f, 0.5)[1]
     @test g isa Real
+end
+
+using TopOpt.Utilities: get_ρ, get_ρ_dρ, density
+
+@testset "get_ρ - penalized density computation" begin
+    # Note: PENALTY_BEFORE_INTERPOLATION is a compile-time preference.
+    # The tests below verify the function behaves correctly for the current configuration.
+    # To test the other mode, restart Julia with the preference changed.
+    @info "Testing get_ρ with PENALTY_BEFORE_INTERPOLATION = $(TopOpt.PENALTY_BEFORE_INTERPOLATION)"
+
+    # Test with PowerPenalty
+    @testset "PowerPenalty" begin
+        penalty = PowerPenalty(3.0)
+        xmin = 0.001
+
+        # Test basic computation at x_e = 0.5
+        x_e = 0.5
+        result = get_ρ(x_e, penalty, xmin)
+
+        # Manual computation based on current mode
+        if TopOpt.PENALTY_BEFORE_INTERPOLATION
+            # density(penalty(x_e), xmin)
+            expected = density(penalty(x_e), xmin)
+        else
+            # penalty(density(x_e, xmin))
+            expected = penalty(density(x_e, xmin))
+        end
+        @test result ≈ expected
+
+        # Test edge case: x_e = 0.0
+        result_0 = get_ρ(0.0, penalty, xmin)
+        if TopOpt.PENALTY_BEFORE_INTERPOLATION
+            expected_0 = density(penalty(0.0), xmin)
+        else
+            expected_0 = penalty(density(0.0, xmin))
+        end
+        @test result_0 ≈ expected_0
+
+        # Test edge case: x_e = 1.0
+        result_1 = get_ρ(1.0, penalty, xmin)
+        if TopOpt.PENALTY_BEFORE_INTERPOLATION
+            expected_1 = density(penalty(1.0), xmin)
+        else
+            expected_1 = penalty(density(1.0, xmin))
+        end
+        @test result_1 ≈ expected_1
+
+        # Test with different xmin values
+        for xmin_test in [0.0, 0.001, 0.01, 0.1]
+            result_xmin = get_ρ(0.5, penalty, xmin_test)
+            if TopOpt.PENALTY_BEFORE_INTERPOLATION
+                expected_xmin = density(penalty(0.5), xmin_test)
+            else
+                expected_xmin = penalty(density(0.5, xmin_test))
+            end
+            @test result_xmin ≈ expected_xmin
+        end
+
+        # Test with different penalty values
+        for p in [1.0, 2.0, 3.0, 5.0]
+            penalty_p = PowerPenalty(p)
+            result_p = get_ρ(0.5, penalty_p, xmin)
+            if TopOpt.PENALTY_BEFORE_INTERPOLATION
+                expected_p = density(penalty_p(0.5), xmin)
+            else
+                expected_p = penalty_p(density(0.5, xmin))
+            end
+            @test result_p ≈ expected_p
+        end
+    end
+
+    # Test with RationalPenalty
+    @testset "RationalPenalty" begin
+        penalty = RationalPenalty(3.0)
+        xmin = 0.001
+
+        x_e = 0.5
+        result = get_ρ(x_e, penalty, xmin)
+
+        if TopOpt.PENALTY_BEFORE_INTERPOLATION
+            expected = density(penalty(x_e), xmin)
+        else
+            expected = penalty(density(x_e, xmin))
+        end
+        @test result ≈ expected
+
+        # Test edge cases
+        @test get_ρ(0.0, penalty, xmin) ≈ (TopOpt.PENALTY_BEFORE_INTERPOLATION ? density(penalty(0.0), xmin) : penalty(density(0.0, xmin)))
+        @test get_ρ(1.0, penalty, xmin) ≈ (TopOpt.PENALTY_BEFORE_INTERPOLATION ? density(penalty(1.0), xmin) : penalty(density(1.0, xmin)))
+    end
+
+    # Test with SinhPenalty
+    @testset "SinhPenalty" begin
+        penalty = SinhPenalty(3.0)
+        xmin = 0.001
+
+        x_e = 0.5
+        result = get_ρ(x_e, penalty, xmin)
+
+        if TopOpt.PENALTY_BEFORE_INTERPOLATION
+            expected = density(penalty(x_e), xmin)
+        else
+            expected = penalty(density(x_e, xmin))
+        end
+        @test result ≈ expected
+
+        # Test edge cases
+        @test get_ρ(0.0, penalty, xmin) ≈ (TopOpt.PENALTY_BEFORE_INTERPOLATION ? density(penalty(0.0), xmin) : penalty(density(0.0, xmin)))
+        @test get_ρ(1.0, penalty, xmin) ≈ (TopOpt.PENALTY_BEFORE_INTERPOLATION ? density(penalty(1.0), xmin) : penalty(density(1.0, xmin)))
+    end
+
+    # Test with ProjectedPenalty
+    @testset "ProjectedPenalty" begin
+        base_penalty = PowerPenalty(3.0)
+        proj = HeavisideProjection(5.0)
+        penalty = ProjectedPenalty(base_penalty, proj)
+        xmin = 0.001
+
+        x_e = 0.5
+        result = get_ρ(x_e, penalty, xmin)
+
+        if TopOpt.PENALTY_BEFORE_INTERPOLATION
+            expected = density(penalty(x_e), xmin)
+        else
+            expected = penalty(density(x_e, xmin))
+        end
+        @test result ≈ expected
+
+        # Test with different base penalties
+        rp_base = RationalPenalty(2.0)
+        rp_proj = ProjectedPenalty(rp_base, proj)
+        result_rp = get_ρ(0.5, rp_proj, xmin)
+        if TopOpt.PENALTY_BEFORE_INTERPOLATION
+            expected_rp = density(rp_proj(0.5), xmin)
+        else
+            expected_rp = rp_proj(density(0.5, xmin))
+        end
+        @test result_rp ≈ expected_rp
+    end
+
+    # Test type stability
+    @testset "Type stability" begin
+        penalty = PowerPenalty(3.0)
+        xmin = 0.001
+        x_e = 0.5
+
+        result = get_ρ(x_e, penalty, xmin)
+        @test result isa Float64
+
+        # Test with Float32
+        penalty_f32 = PowerPenalty(3.0f0)
+        xmin_f32 = 0.001f0
+        x_e_f32 = 0.5f0
+
+        result_f32 = get_ρ(x_e_f32, penalty_f32, xmin_f32)
+        @test result_f32 isa Float32
+    end
+
+    # Test mathematical properties
+    @testset "Mathematical properties" begin
+        penalty = PowerPenalty(3.0)
+        xmin = 0.001
+
+        # For any valid input, result should be between xmin and penalty(1.0) (or vice versa)
+        for x_e in [0.0, 0.25, 0.5, 0.75, 1.0]
+            result = get_ρ(x_e, penalty, xmin)
+            # Result should be in reasonable range
+            @test result >= min(xmin, penalty(xmin))
+            @test result <= max(penalty(1.0), 1.0)
+        end
+
+        # Test monotonicity: higher x_e should give higher result (for typical penalties)
+        # Note: This may not hold for all penalty/projection combinations
+        x1, x2 = 0.3, 0.7
+        r1 = get_ρ(x1, penalty, xmin)
+        r2 = get_ρ(x2, penalty, xmin)
+        @test r1 < r2  # PowerPenalty should preserve ordering
+    end
+
+    # Test consistency with manual computation
+    @testset "Consistency with manual computation" begin
+        penalty = PowerPenalty(2.0)
+        xmin = 0.01
+        x_e = 0.6
+
+        ρ_computed = get_ρ(x_e, penalty, xmin)
+
+        # Manual step-by-step computation
+        if TopOpt.PENALTY_BEFORE_INTERPOLATION
+            # First apply penalty, then density interpolation
+            penalized = penalty(x_e)  # x_e^p
+            ρ_manual = density(penalized, xmin)  # penalized * (1 - xmin) + xmin
+        else
+            # First apply density interpolation, then penalty
+            interpolated = density(x_e, xmin)  # x_e * (1 - xmin) + xmin
+            ρ_manual = penalty(interpolated)  # interpolated^p
+        end
+
+        @test ρ_computed ≈ ρ_manual
+    end
+end
+
+@testset "get_ρ_dρ - penalized density with derivative" begin
+    @info "Testing get_ρ_dρ with PENALTY_BEFORE_INTERPOLATION = $(TopOpt.PENALTY_BEFORE_INTERPOLATION)"
+
+    @testset "PowerPenalty derivatives" begin
+        penalty = PowerPenalty(3.0)
+        xmin = 0.001
+
+        # Test at x_e = 0.5
+        x_e = 0.5
+        ρ_val, dρ = get_ρ_dρ(x_e, penalty, xmin)
+
+        # Verify the value matches get_ρ
+        @test ρ_val ≈ get_ρ(x_e, penalty, xmin)
+
+        # Verify derivative using finite differences
+        ε = 1e-8
+        ρ_plus = get_ρ(x_e + ε, penalty, xmin)
+        ρ_minus = get_ρ(x_e - ε, penalty, xmin)
+        fd_derivative = (ρ_plus - ρ_minus) / (2 * ε)
+
+        @test dρ ≈ fd_derivative rtol = 1e-5
+
+        # Test at other points
+        for x_test in [0.1, 0.3, 0.7, 0.9]
+            ρ_val_t, dρ_t = get_ρ_dρ(x_test, penalty, xmin)
+
+            ρ_plus_t = get_ρ(x_test + ε, penalty, xmin)
+            ρ_minus_t = get_ρ(x_test - ε, penalty, xmin)
+            fd_derivative_t = (ρ_plus_t - ρ_minus_t) / (2 * ε)
+
+            @test dρ_t ≈ fd_derivative_t rtol = 1e-5
+        end
+    end
+
+    @testset "RationalPenalty derivatives" begin
+        penalty = RationalPenalty(3.0)
+        xmin = 0.001
+
+        x_e = 0.5
+        ρ_val, dρ = get_ρ_dρ(x_e, penalty, xmin)
+
+        @test ρ_val ≈ get_ρ(x_e, penalty, xmin)
+
+        ε = 1e-8
+        ρ_plus = get_ρ(x_e + ε, penalty, xmin)
+        ρ_minus = get_ρ(x_e - ε, penalty, xmin)
+        fd_derivative = (ρ_plus - ρ_minus) / (2 * ε)
+
+        @test dρ ≈ fd_derivative rtol = 1e-5
+    end
+
+    @testset "SinhPenalty derivatives" begin
+        penalty = SinhPenalty(3.0)
+        xmin = 0.001
+
+        x_e = 0.5
+        ρ_val, dρ = get_ρ_dρ(x_e, penalty, xmin)
+
+        @test ρ_val ≈ get_ρ(x_e, penalty, xmin)
+
+        ε = 1e-8
+        ρ_plus = get_ρ(x_e + ε, penalty, xmin)
+        ρ_minus = get_ρ(x_e - ε, penalty, xmin)
+        fd_derivative = (ρ_plus - ρ_minus) / (2 * ε)
+
+        @test dρ ≈ fd_derivative rtol = 1e-5
+    end
+
+    @testset "ProjectedPenalty derivatives" begin
+        base_penalty = PowerPenalty(3.0)
+        proj = HeavisideProjection(5.0)
+        penalty = ProjectedPenalty(base_penalty, proj)
+        xmin = 0.001
+
+        x_e = 0.5
+        ρ_val, dρ = get_ρ_dρ(x_e, penalty, xmin)
+
+        @test ρ_val ≈ get_ρ(x_e, penalty, xmin)
+
+        ε = 1e-8
+        ρ_plus = get_ρ(x_e + ε, penalty, xmin)
+        ρ_minus = get_ρ(x_e - ε, penalty, xmin)
+        fd_derivative = (ρ_plus - ρ_minus) / (2 * ε)
+
+        @test dρ ≈ fd_derivative rtol = 1e-5
+    end
+
+    @testset "Edge case derivatives" begin
+        penalty = PowerPenalty(3.0)
+        xmin = 0.001
+
+        # Test at boundaries
+        for x_e in [0.0, 1.0]
+            ρ_val, dρ = get_ρ_dρ(x_e, penalty, xmin)
+            @test ρ_val ≈ get_ρ(x_e, penalty, xmin)
+            @test isfinite(dρ)
+        end
+
+        # Test with xmin = 0.0
+        ρ_val, dρ = get_ρ_dρ(0.5, penalty, 0.0)
+        @test ρ_val ≈ get_ρ(0.5, penalty, 0.0)
+        @test isfinite(dρ)
+    end
 end
 
 @testset "getprevpenalty" begin

--- a/test/Utilities/test_show.jl
+++ b/test/Utilities/test_show.jl
@@ -53,4 +53,11 @@ using TopOpt, Test
         show(io, MIME("text/plain"), result)
         @test String(take!(io)) == "TopOpt linear elasticity result\n"
     end
+
+    @testset "visualize fallback function" begin
+        # Test that visualize throws an error without Makie loaded
+        err = @test_throws ErrorException visualize([1, 2, 3])
+        @test occursin("visualize", sprint(show, err.value))
+        @test occursin("Makie", sprint(show, err.value))
+    end
 end

--- a/test/Utilities/test_utils.jl
+++ b/test/Utilities/test_utils.jl
@@ -176,3 +176,40 @@ end
     K_test = @SMatrix [5.0 1.0; 2.0 3.0]
     @test sumdiag(K_test) == sum(diag(K_test))
 end
+
+@testset "visualize fallback function" begin
+    # Test that visualize throws informative error when Makie is not loaded
+    err = try
+        visualize(42)
+        nothing
+    catch e
+        e
+    end
+    @test err isa ErrorException
+    @test occursin("visualize", err.msg)
+    @test occursin("Int64", err.msg)
+    @test occursin("Makie", err.msg)
+
+    # Test with different types
+    err_str = try
+        visualize("hello")
+        nothing
+    catch e
+        e
+    end
+    @test err_str isa ErrorException
+    @test occursin("String", err_str.msg)
+
+    # Test with keyword arguments
+    err_kw = try
+        visualize(42; color=:red)
+        nothing
+    catch e
+        e
+    end
+    @test err_kw isa ErrorException
+    @test occursin("Int64", err_kw.msg)
+
+    # Test that visualize is exported
+    @test isdefined(@__MODULE__, :visualize)
+end

--- a/test/topopt_problems/test_elementmatrix.jl
+++ b/test/topopt_problems/test_elementmatrix.jl
@@ -1,0 +1,229 @@
+using Test
+using TopOpt.TopOptProblems: ElementMatrix, rawmatrix, bcmatrix
+using StaticArrays
+using LinearAlgebra
+
+@testset "ElementMatrix Base.convert" begin
+    @testset "StaticMatrix convert - no boundary conditions" begin
+        # Test 1: StaticMatrix 2x2 without bc_dofs
+        T = Float64
+        N = 2
+        
+        # Create sample element stiffness matrices
+        K1 = @SMatrix [4.0 -1.0; -1.0 4.0]
+        K2 = @SMatrix [5.0 -2.0; -2.0 5.0]
+        Kes = [K1, K2]
+        
+        # No boundary conditions
+        bc_dofs = Int[]
+        dof_cells = Dict{Int, Vector{Tuple{Int, Int}}}()
+        
+        element_Kes = Base.convert(Vector{<:ElementMatrix}, Kes; bc_dofs=bc_dofs, dof_cells=dof_cells)
+        
+        @test length(element_Kes) == 2
+        @test element_Kes[1] isa ElementMatrix{T, <:SMatrix{N,N,T}}
+        
+        # All masks should be true
+        @test all(element_Kes[1].mask .== true)
+        @test all(element_Kes[2].mask .== true)
+        
+        # Verify matrix values are set
+        @test element_Kes[1].matrix[1, 1] ≈ 4.0
+        @test element_Kes[1].matrix[2, 2] ≈ 4.0
+        @test element_Kes[2].matrix[1, 1] ≈ 5.0
+        @test element_Kes[2].matrix[2, 2] ≈ 5.0
+        
+        # meandiag is computed as sum of diagonal (4+4=8, 5+5=10)
+        @test element_Kes[1].meandiag ≈ 8.0
+        @test element_Kes[2].meandiag ≈ 10.0
+    end
+
+    @testset "StaticMatrix 3x3 - no boundary conditions" begin
+        T = Float64
+        N = 3
+        
+        # Create 3x3 StaticMatrices
+        K1 = @SMatrix [4.0 -1.0 0.0; -1.0 4.0 -1.0; 0.0 -1.0 4.0]
+        K2 = @SMatrix [5.0 -2.0 0.0; -2.0 5.0 -2.0; 0.0 -2.0 5.0]
+        Kes = [K1, K2]
+        
+        # No boundary conditions
+        bc_dofs = Int[]
+        dof_cells = Dict{Int, Vector{Tuple{Int, Int}}}()
+        
+        element_Kes = Base.convert(Vector{<:ElementMatrix}, Kes; bc_dofs=bc_dofs, dof_cells=dof_cells)
+        
+        @test length(element_Kes) == 2
+        
+        # All masks should be true
+        @test all(element_Kes[1].mask .== true)
+        @test all(element_Kes[2].mask .== true)
+        
+        # Verify matrices are copied
+        @test element_Kes[1].matrix[1, 1] ≈ 4.0
+        @test element_Kes[2].matrix[2, 2] ≈ 5.0
+    end
+
+    @testset "StaticMatrix Symmetric wrapper - no boundary conditions" begin
+        T = Float64
+        N = 2
+        
+        # Create Symmetric wrapped StaticMatrices
+        K1 = Symmetric(@SMatrix [4.0 -1.0; -1.0 4.0])
+        K2 = Symmetric(@SMatrix [5.0 -2.0; -2.0 5.0])
+        Kes = [K1, K2]
+        
+        bc_dofs = Int[]
+        dof_cells = Dict{Int, Vector{Tuple{Int, Int}}}()
+        
+        element_Kes = Base.convert(Vector{<:ElementMatrix}, Kes; bc_dofs=bc_dofs, dof_cells=dof_cells)
+        
+        @test length(element_Kes) == 2
+        @test element_Kes[1] isa Symmetric{T, <:ElementMatrix{T}}
+        
+        # All masks should be true
+        @test all(element_Kes[1].data.mask .== true)
+        @test all(element_Kes[2].data.mask .== true)
+        
+        # Verify matrix values
+        @test element_Kes[1].data.matrix[1, 1] ≈ 4.0
+        @test element_Kes[2].data.matrix[2, 2] ≈ 5.0
+        
+        # meandiag is sum of diagonal
+        @test element_Kes[1].data.meandiag ≈ 8.0
+        @test element_Kes[2].data.meandiag ≈ 10.0
+    end
+
+    @testset "Empty bc_dofs (no boundary conditions)" begin
+        N = 2
+        K1 = @SMatrix [4.0 -1.0; -1.0 4.0]
+        K2 = @SMatrix [5.0 -2.0; -2.0 5.0]
+        Kes = [K1, K2]
+        
+        bc_dofs = Int[]
+        dof_cells = Dict{Int, Vector{Tuple{Int, Int}}}()
+        
+        element_Kes = Base.convert(Vector{<:ElementMatrix}, Kes; bc_dofs=bc_dofs, dof_cells=dof_cells)
+        
+        @test length(element_Kes) == 2
+        
+        # All masks should be true
+        @test all(element_Kes[1].mask .== true)
+        @test all(element_Kes[2].mask .== true)
+        
+        # Verify matrices are set correctly
+        @test element_Kes[1].matrix[1, 1] ≈ 4.0
+        @test element_Kes[2].matrix[2, 2] ≈ 5.0
+    end
+
+    @testset "Single element matrix - no BCs" begin
+        N = 2
+        K1 = @SMatrix [4.0 -1.0; -1.0 4.0]
+        Kes = [K1]
+        
+        bc_dofs = Int[]
+        dof_cells = Dict{Int, Vector{Tuple{Int, Int}}}()
+        
+        element_Kes = Base.convert(Vector{<:ElementMatrix}, Kes; bc_dofs=bc_dofs, dof_cells=dof_cells)
+        
+        @test length(element_Kes) == 1
+        @test all(element_Kes[1].mask .== true)
+    end
+
+    @testset "Different numeric types" begin
+        # Test with Float32
+        T = Float32
+        N = 2
+        
+        K1 = @SMatrix T[4.0f0 -1.0f0; -1.0f0 4.0f0]
+        K2 = @SMatrix T[5.0f0 -2.0f0; -2.0f0 5.0f0]
+        Kes = [K1, K2]
+        
+        bc_dofs = Int[]
+        dof_cells = Dict{Int, Vector{Tuple{Int, Int}}}()
+        
+        element_Kes = Base.convert(Vector{<:ElementMatrix}, Kes; bc_dofs=bc_dofs, dof_cells=dof_cells)
+        
+        @test eltype(element_Kes[1].matrix) == Float32
+        @test element_Kes[1].meandiag isa Float32
+    end
+
+    @testset "RawMatrix and BCMatrix functions" begin
+        N = 2
+        K1 = @SMatrix [4.0 -1.0; -1.0 4.0]
+        Kes = [K1]
+        
+        bc_dofs = Int[]
+        dof_cells = Dict{Int, Vector{Tuple{Int, Int}}}()
+        
+        element_Kes = Base.convert(Vector{<:ElementMatrix}, Kes; bc_dofs=bc_dofs, dof_cells=dof_cells)
+        em = element_Kes[1]
+        
+        # Test rawmatrix
+        @test rawmatrix(em) ≈ K1
+        
+        # Test bcmatrix (no BCs, should be same as original)
+        bcm = bcmatrix(em)
+        @test bcm ≈ K1
+    end
+
+    @testset "Symmetric ElementMatrix rawmatrix and bcmatrix" begin
+        N = 2
+        K1 = Symmetric(@SMatrix [4.0 -1.0; -1.0 4.0])
+        Kes = [K1]
+        
+        bc_dofs = Int[]
+        dof_cells = Dict{Int, Vector{Tuple{Int, Int}}}()
+        
+        element_Kes = Base.convert(Vector{<:ElementMatrix}, Kes; bc_dofs=bc_dofs, dof_cells=dof_cells)
+        em = element_Kes[1]
+        
+        # Test rawmatrix on Symmetric wrapper
+        rm = rawmatrix(em)
+        @test rm isa Symmetric
+        @test rm.data ≈ K1.data
+    end
+
+    @testset "ElementMatrix struct basic functionality" begin
+        # Test creating ElementMatrix directly
+        mat = @SMatrix [4.0 -1.0; -1.0 4.0]
+        mask = SVector{2, Bool}(true, false)
+        meandiag_val = 8.0
+        
+        em = ElementMatrix(mat, mask, meandiag_val)
+        
+        @test em.matrix ≈ mat
+        @test em.mask == mask
+        @test em.meandiag ≈ meandiag_val
+        
+        # Test rawmatrix
+        @test rawmatrix(em) ≈ mat
+        
+        # Test bcmatrix - should zero out row/col 2 (where mask is false)
+        bcm = bcmatrix(em)
+        @test bcm[1, 1] ≈ 4.0
+        @test bcm[1, 2] ≈ 0.0
+        @test bcm[2, 1] ≈ 0.0
+        @test bcm[2, 2] ≈ 0.0
+    end
+
+    @testset "Symmetric ElementMatrix wrapper basic functionality" begin
+        mat = @SMatrix [4.0 -1.0; -1.0 4.0]
+        mask = SVector{2, Bool}(true, false)
+        meandiag_val = 8.0
+        
+        em = Symmetric(ElementMatrix(mat, mask, meandiag_val))
+        
+        # Test rawmatrix - returns Symmetric{SMatrix}, not Symmetric{ElementMatrix}
+        rm = rawmatrix(em)
+        @test rm isa Symmetric
+        @test rm.data ≈ mat
+        
+        # Test bcmatrix
+        bcm = bcmatrix(em)
+        @test bcm[1, 1] ≈ 4.0
+        @test bcm[1, 2] ≈ 0.0
+        @test bcm[2, 1] ≈ 0.0
+        @test bcm[2, 2] ≈ 0.0
+    end
+end


### PR DESCRIPTION
This pull request primarily adds comprehensive tests for the `ElementStressTensor` and `von_mises` functionality, improves test coverage for compliance and mean compliance computations, and fixes a minor typo in a function name. The changes enhance the reliability and correctness of the TopOpt codebase, especially around stress tensor calculations, compliance warnings, and type consistency.

**New and Improved Test Coverage:**

* Added a complete test suite for the `ElementStressTensor` call interface, including checks for element/global dofs, stress tensor properties, gradient integration, and density effects. Also thoroughly tests the `von_mises` function for 2D/3D tensors, error handling, type stability, and symmetry. (`test/Functions/test_element_stress_tensor.jl`)
* Added a new test file for `compute_mean_compliance` with `TraceEstimationSVDMean`, covering correctness, consistency with exact/approximate methods, sample counts, density values, gradient accumulation, solver state integration, and method structure. (`test/Functions/test_compute_mean_compliance_svd.jl`)
* Added a test for compliance warnings when a vector input is passed, ensuring the warning is issued and the result is valid. (`test/Functions/test_common_fns.jl`)

**Bug Fixes and Type Improvements:**

* Fixed a typo in the private function call for element stress tensor calculation from `_element_stres_tensor` to `_element_stress_tensor`. (`src/Functions/stress_tensor.jl`)
* Ensured that `get_f(problem, vars::Array)` uses the correct floating point type for consistency and type stability. (`src/TopOptProblems/assemble.jl`)

**Minor Improvements:**

* Added an import of `getncells` from `Ferrite` in the fixed element projector test for completeness. (`test/Functions/test_fixed_element.jl`)