### PR TITLE
Document FixedElementProjector and the fixed-element projection API

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,8 +8,15 @@ using DocumenterCitations
 include("generate.jl")
 
 GENERATED_EXAMPLES = [
-    joinpath("examples", f) for
-    f in ("simp.md", "beso.md", "geso.md", "csimp.md", "global_stress.md", "TOBS.md", "heat_tree.md")
+    joinpath("examples", f) for f in (
+        "simp.md",
+        "beso.md",
+        "geso.md",
+        "csimp.md",
+        "global_stress.md",
+        "TOBS.md",
+        "heat_tree.md",
+    )
 ]
 
 bib = CitationBibliography(joinpath(@__DIR__, "biblio", "ref.bib"))
@@ -24,7 +31,11 @@ makedocs(;
         "Problem types" => "examples/problem.md",
         "Functions" => "functions.md",
         "Examples" => GENERATED_EXAMPLES,
-        "API Reference" => ["reference/TopOptProblems.md", "reference/Algorithms.md"],
+        "API Reference" => [
+            "reference/TopOptProblems.md",
+            "reference/Algorithms.md",
+            "reference/Functions.md",
+        ],
         "Bibliography" => "bibliography.md",
     ],
 )

--- a/docs/src/functions.md
+++ b/docs/src/functions.md
@@ -118,3 +118,18 @@ All the following functions are defined in a differentiable way and you can use 
   p0 = nn_model.init_params
   ```
   - **Usage example**: `x = train_func(p)`
+
+## Fixed element projection
+  - **Function name**: `get_fixed_element_projector`
+  - **Description**: Builds a `FixedElementProjector` that maps a reduced vector of free design variables to a full element density vector, with black (solid, density = 1) and white (void, density = 0) elements held fixed. This lets you exclude fixed elements from the optimization variables while keeping the full density vector that the solver and objective functions expect. The projector is differentiable (a `ChainRulesCore.rrule` propagates gradients only through the free elements), so it composes with the other functions on this page.
+  - **Input(s)**: A problem (e.g. `PointLoadCantilever`, `HalfMBB`) or an element count `nel::Int`, followed by `black_cells` and `white_cells` — vectors of element indices to fix solid and void.
+  - **Output**: A `FixedElementProjector` `p` such that `ρ = p(x_free)` returns the full density vector.
+  - **Constructor example**:
+  ```
+  projector = get_fixed_element_projector(problem, black_cells, white_cells)
+  ```
+  - **Usage example**:
+  ```
+  x_free = fill(0.5, get_free_variable_count(projector))
+  ρ = projector(x_free)
+  ```

--- a/docs/src/reference/Functions.md
+++ b/docs/src/reference/Functions.md
@@ -1,0 +1,33 @@
+# `Functions`
+
+This sub-module of `TopOpt` defines the differentiable building blocks used in
+topology optimization formulations. The narrative descriptions and constructor
+examples live in the [Functions](@ref) page; the entries below render the full
+docstrings, including the fixed-element projection helpers.
+
+```@meta
+CurrentModule = TopOpt.Functions
+```
+
+## Fixed element projection
+
+`FixedElementProjector` maps a reduced vector of free design variables to a
+full element density vector, holding black (solid) and white (void) elements
+fixed. Use `get_fixed_element_projector` to construct one from a problem or an
+element count.
+
+```@docs
+FixedElementProjector
+```
+
+```@docs
+get_fixed_element_projector
+```
+
+```@docs
+get_free_variables
+```
+
+```@docs
+get_free_variable_count
+```


### PR DESCRIPTION
## Summary

The fixed-element projection feature (introduced in #220, addressing #155) had docstrings and exports but was not surfaced in the rendered documentation — a user browsing the built docs would not find it anywhere.

This PR surfaces it in two places:

- **`docs/src/functions.md`** — a new "Fixed element projection" section in the existing bullet-list style used by the other differentiable building blocks (`Compliance`, `Volume`, `DensityFilter`, etc.).
- **`docs/src/reference/Functions.md`** (new page) — `@docs` blocks that render the full docstrings of `FixedElementProjector`, `get_fixed_element_projector`, `get_free_variables`, and `get_free_variable_count`. Added to the "API Reference" list in `docs/make.jl`.

### Why a new reference page

The existing reference pages (`TopOptProblems.md`, `Algorithms.md`) each set `CurrentModule` to a sub-module and pull docstrings via `@docs`. There was no `Functions.md` reference page, so the `Functions` sub-module's docstrings (including these) were never rendered. The new page sets `CurrentModule = TopOpt.Functions` and documents the fixed-element projection helpers.

### Docs preview

Once CI runs, `deploydocs` (`push_preview=true` in `docs/make.jl`) publishes a preview of this branch.

Assisted-by: GLM-5.2 via opencode