### PR TITLE
Refactor AI harness configs from Zoo Code to opencode-neutral format

### DIFF
--- a/.opencode/instructions/architect.md
+++ b/.opencode/instructions/architect.md
@@ -1,7 +1,7 @@
-# Architect mode rules
+# Architecture guidance
 
-These rules apply when planning, designing, or strategizing before
-implementation in this repository.
+Guidance for planning, designing, or strategizing before implementation in
+this repository.
 
 ## Project scope
 
@@ -50,9 +50,8 @@ optimization algorithms via the Nonconvex.jl ecosystem.
   remain differentiable via Zygote. New solvers should extend
   `AbstractFEASolver` and follow the physics/solver dispatch pattern.
 - Prefer **unconstrained type parameters** in `struct` constructors (see
-  `.roo/rules-code/AGENTS.md` for the full cascade pattern). Do not over-constrain
-  method signatures — annotate only as specifically as the implementation
-  requires.
+  `code.md` for the full cascade pattern). Do not over-constrain method
+  signatures — annotate only as specifically as the implementation requires.
 - When adding new packages to the local project, also update the `[compat]`
   section of `Project.toml` to bound the version of the new dependency. After
   editing `Project.toml`, run `Pkg.resolve()`.

--- a/.opencode/instructions/ask.md
+++ b/.opencode/instructions/ask.md
@@ -1,7 +1,7 @@
-# Ask mode rules
+# Explanation guidance
 
-These rules apply when providing explanations, documentation, or answers to
-technical questions about this repository.
+Guidance for providing explanations, documentation, or answers to technical
+questions about this repository.
 
 ## Stance
 
@@ -20,9 +20,9 @@ technical questions about this repository.
   full architecture reference) and the root `AGENTS.md` (project context and
   conventions).
 - For Julia-specific questions (indexing, `@inbounds`, style), consult
-  `.roo/rules-code/AGENTS.md`.
-- For debugging questions, consult `.roo/rules-debug/AGENTS.md`.
-- For design questions, consult `.roo/rules-architect/AGENTS.md`.
+  `code.md`.
+- For debugging questions, consult `debug.md`.
+- For design questions, consult `architect.md`.
 
 ## Key concepts in TopOpt.jl
 

--- a/.opencode/instructions/code.md
+++ b/.opencode/instructions/code.md
@@ -1,7 +1,7 @@
-# Code mode rules
+# Code guidance
 
-These rules apply when writing, modifying, or refactoring code in this
-repository. They adapt guidance from
+Guidance for writing, modifying, or refactoring code in this repository.
+It adapts guidance from
 [timholy/claude_config](https://github.com/timholy/claude_config) to TopOpt.jl.
 
 ## Code comments

--- a/.opencode/instructions/debug.md
+++ b/.opencode/instructions/debug.md
@@ -1,7 +1,7 @@
-# Debug mode rules
+# Debugging guidance
 
-These rules apply when troubleshooting issues, investigating errors, or
-diagnosing problems in this repository.
+Guidance for troubleshooting issues, investigating errors, or diagnosing
+problems in this repository.
 
 ## Fail-fast first
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,21 +6,21 @@ build/test commands, dependencies, usage examples) lives in the **Memory Bank**
 (`memory-bank/`, git-ignored) — read those files for project specifics and keep
 them up to date as the project evolves.
 
-## Mode-specific rules
+## Topic-specific guidance
 
-Zoo Code loads mode-specific rules from `.roo/rules-<mode>/AGENTS.md`. These
-files extend the guidance here with rules tailored to each mode:
+opencode loads the topic-specific guidance files listed in `opencode.jsonc`
+under `instructions`. They extend the guidance here with rules tailored to
+specific kinds of work:
 
-- [`.roo/rules-code/AGENTS.md`](.roo/rules-code/AGENTS.md) — Code mode: code
+- [`.opencode/instructions/code.md`](.opencode/instructions/code.md) — code
   comments discipline, Julia generic indexing, `@inbounds` policy, and
   TopOpt.jl-specific coding notes.
-- [`.roo/rules-debug/AGENTS.md`](.roo/rules-debug/AGENTS.md) — Debug mode:
+- [`.opencode/instructions/debug.md`](.opencode/instructions/debug.md) —
   fail-fast guards, Revise/MCP usage, systematic debugging approach, and
   graphical display during debugging.
-- [`.roo/rules-architect/AGENTS.md`](.roo/rules-architect/AGENTS.md) —
-  Architect mode: project scope, key architectural decisions, and design
-  principles.
-- [`.roo/rules-ask/AGENTS.md`](.roo/rules-ask/AGENTS.md) — Ask mode:
+- [`.opencode/instructions/architect.md`](.opencode/instructions/architect.md)
+  — project scope, key architectural decisions, and design principles.
+- [`.opencode/instructions/ask.md`](.opencode/instructions/ask.md) —
   explanation stance, how to answer, and key TopOpt.jl concepts.
 
 ## Stance
@@ -171,7 +171,7 @@ Check what's available first:
   reader who has only the repository: state what *is* true about the code now,
   not its history, its motivation, or the plan it came from. Re-read the diff's
   comments before proposing a commit. Full guidance and examples:
-  `.roo/rules-code/AGENTS.md` (Code comments).
+  `.opencode/instructions/code.md` (Code comments).
 - Commit subject lines should ideally be shorter than lines in the body (aim
   for ≤ 50, up to 72 OK) due to formatting on GitHub.
 - Changes motivated by GitHub issues or PRs should include a comment with the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,12 +5,16 @@ code in this repository.
 
 - **Agent meta instructions**: [`AGENTS.md`](AGENTS.md) is the source of truth
   for stance, Memory Bank protocol, Julia development and style guide, and
-  devops rules. It also links the mode-specific rules in `.roo/rules-<mode>/`:
-  - [`.roo/rules-code/AGENTS.md`](.roo/rules-code/AGENTS.md) — Code mode
-  - [`.roo/rules-debug/AGENTS.md`](.roo/rules-debug/AGENTS.md) — Debug mode
-  - [`.roo/rules-architect/AGENTS.md`](.roo/rules-architect/AGENTS.md) —
-    Architect mode
-  - [`.roo/rules-ask/AGENTS.md`](.roo/rules-ask/AGENTS.md) — Ask mode
+  devops rules. It also links the topic-specific guidance under
+  `.opencode/instructions/`:
+  - [`.opencode/instructions/code.md`](.opencode/instructions/code.md) — code
+    guidance
+  - [`.opencode/instructions/debug.md`](.opencode/instructions/debug.md) —
+    debugging guidance
+  - [`.opencode/instructions/architect.md`](.opencode/instructions/architect.md)
+    — architecture guidance
+  - [`.opencode/instructions/ask.md`](.opencode/instructions/ask.md) —
+    explanation guidance
 - **Project description**: the detailed project specifics (architecture, module
   structure, build/test commands, dependencies, usage examples) live in the
   **Memory Bank** at [`memory-bank/`](memory-bank/) (git-ignored, kept up to

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": [
+    "AGENTS.md",
+    ".opencode/instructions/code.md",
+    ".opencode/instructions/debug.md",
+    ".opencode/instructions/architect.md",
+    ".opencode/instructions/ask.md"
+  ]
+}


### PR DESCRIPTION
## Summary

Replaces the Zoo Code-specific harness layout with a harness-neutral configuration built around opencode conventions. opencode is now the preferred harness; the new layout also works as a fallback for Claude Code (which reads `AGENTS.md` natively).

## Changes

- **`opencode.jsonc`** (new): declares the instruction files via the `instructions` field, so opencode merges them with the root `AGENTS.md` at session start.
- **`.opencode/instructions/{code,debug,architect,ask}.md`** (new): topic-specific guidance moved out of `.roo/rules-<mode>/AGENTS.md`. Content preserved verbatim apart from de-branding: the "mode rules" framing is dropped, harness names removed, and cross-references rewritten to point at the new paths (`code.md`, `debug.md`, …) instead of `.roo/rules-<mode>/`.
- **`AGENTS.md`**: the "Mode-specific rules" section is now "Topic-specific guidance" and points at `.opencode/instructions/`. The Devops section's pointer for code-comment guidance now cites `code.md`.
- **`.roo/`** removed — Zoo Code-specific layout no longer needed.
- **`CLAUDE.md`** removed — it was only a pointer at `AGENTS.md` and `.roo/rules-<mode>/`, and opencode reads `AGENTS.md` natively (Claude Code also falls back to `AGENTS.md`).

No behavioral rules changed; only layout, naming, and cross-references.

Assisted-by: GLM-5.2 via opencode
