### PR TITLE
Add tutorials to docs sidebar with local links

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,10 +8,11 @@ makedocs(;
     format=Documenter.HTML(; prettyurls=get(ENV, "CI", nothing) == "true"),
     doctest=true,
     checkdocs=:all,
-    warnonly=false,
+    warnonly=[:cross_references],
     plugins=[bib],
     pages=[
         "Home" => "index.md",
+        "Tutorials" => "tutorials/index.md",
         "Problem types" => [
             "Continuum" => "reference/TopOptProblems.md",
             "Truss" => "reference/TrussTopOptProblems.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,6 @@ makedocs(;
     format=Documenter.HTML(; prettyurls=get(ENV, "CI", nothing) == "true"),
     doctest=true,
     checkdocs=:all,
-    warnonly=[:cross_references],
     plugins=[bib],
     pages=[
         "Home" => "index.md",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -96,6 +96,6 @@ TopOpt.jl provides several pre-defined problem types for common test cases:
 - **`TrussProblem`** — General truss topology optimization with stress/buckling constraints
 - **`PointLoadCantileverTruss`** — Truss cantilever with point load
 
-See the [TopOpt Tutorials](https://juliatopopt.github.io/TopOpt.jl/tutorials/index.html) section for complete, commented examples covering
+See the [TopOpt Tutorials](tutorials/index.html) section for complete, commented examples covering
 stress-constrained optimization, heat sinks, multi-material design,
 neural-network parametrization, trusses, and more.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -96,6 +96,6 @@ TopOpt.jl provides several pre-defined problem types for common test cases:
 - **`TrussProblem`** — General truss topology optimization with stress/buckling constraints
 - **`PointLoadCantileverTruss`** — Truss cantilever with point load
 
-See the [TopOpt Tutorials](tutorials/index.html) section for complete, commented examples covering
+See the [TopOpt Tutorials](tutorials/index.md) section for complete, commented examples covering
 stress-constrained optimization, heat sinks, multi-material design,
 neural-network parametrization, trusses, and more.

--- a/docs/src/reference/Algorithms.md
+++ b/docs/src/reference/Algorithms.md
@@ -4,7 +4,7 @@ This sub-module of `TopOpt` defines topology-optimization-specific algorithms
 (`BESO`, `GESO`). General-purpose nonlinear optimization (SIMP via `MMA87`/
 `MMA02`, `TOBSAlg`, `IpoptAlg`, etc.) is handled through
 [`Nonconvex.jl`](https://github.com/JuliaNonconvex/Nonconvex.jl), which
-`TopOpt` re-exports. See the [Tutorials](https://juliatopopt.github.io/TopOpt.jl/tutorials/index.html) for usage.
+`TopOpt` re-exports. See the [Tutorials](../tutorials/index.html) for usage.
 
 ```@meta
 CurrentModule = TopOpt.Algorithms

--- a/docs/src/reference/Algorithms.md
+++ b/docs/src/reference/Algorithms.md
@@ -4,7 +4,7 @@ This sub-module of `TopOpt` defines topology-optimization-specific algorithms
 (`BESO`, `GESO`). General-purpose nonlinear optimization (SIMP via `MMA87`/
 `MMA02`, `TOBSAlg`, `IpoptAlg`, etc.) is handled through
 [`Nonconvex.jl`](https://github.com/JuliaNonconvex/Nonconvex.jl), which
-`TopOpt` re-exports. See the [Tutorials](../tutorials/index.html) for usage.
+`TopOpt` re-exports. See the [Tutorials](../tutorials/index.md) for usage.
 
 ```@meta
 CurrentModule = TopOpt.Algorithms

--- a/docs/src/tutorials/index.md
+++ b/docs/src/tutorials/index.md
@@ -1,0 +1,29 @@
+# Tutorials
+
+The TopOpt.jl tutorials are rendered separately using Quarto.
+
+- **Local build**: run `quarto render` in `docs/tutorials/` and open `_site/index.html`
+- **CI build**: tutorials are rendered by the CI workflow and deployed with the docs site
+- **Online**: visit the [Tutorials](tutorials/index.html) section of the deployed docs
+
+## Available tutorials
+
+| Tutorial | Topic |
+|---|---|
+| [SIMP](simp.qmd) | Solid Isotropic Material with Penalization |
+| [Continuation SIMP](csimp.qmd) | Penalty ramp optimization |
+| [BESO](beso.qmd) | Bi-directional Evolutionary Structural Optimization |
+| [GESO](geso.qmd) | Gradient-based Evolutionary Structural Optimization |
+| [Local Stress](local_stress.qmd) | Local stress-constrained optimization |
+| [Global Stress](global_stress.qmd) | Global stress-constrained optimization |
+| [Truss](truss.qmd) | Truss topology optimization |
+| [Truss Problems](problems_truss.qmd) | Truss problem types |
+| [Mixed-Integer Truss](mixed_integer_truss.qmd) | MINLP truss design |
+| [Buckling](buckling.qmd) | Buckling-constrained truss optimization |
+| [Heat Sink](heat_sink.qmd) | Thermal compliance optimization |
+| [Heat Tree](heat_tree.qmd) | Tree-shaped heat conduction |
+| [Multi-Material](multimaterial.qmd) | Multi-material topology optimization |
+| [TOBS](tobs.qmd) | Topology Optimization of Binary Structures |
+| [Neural (IPOPT)](neural.qmd) | Neural network parametrization with IPOPT |
+| [Neural (Adam)](neural2.qmd) | Neural network parametrization with Adam |
+| [Continuum Problems](problems_continuum.qmd) | Continuum problem types |

--- a/docs/src/tutorials/index.md
+++ b/docs/src/tutorials/index.md
@@ -1,29 +1,6 @@
-# Tutorials
-
-The TopOpt.jl tutorials are rendered separately using Quarto.
-
-- **Local build**: run `quarto render` in `docs/tutorials/` and open `_site/index.html`
-- **CI build**: tutorials are rendered by the CI workflow and deployed with the docs site
-- **Online**: visit the [Tutorials](tutorials/index.html) section of the deployed docs
-
-## Available tutorials
-
-| Tutorial | Topic |
-|---|---|
-| [SIMP](simp.qmd) | Solid Isotropic Material with Penalization |
-| [Continuation SIMP](csimp.qmd) | Penalty ramp optimization |
-| [BESO](beso.qmd) | Bi-directional Evolutionary Structural Optimization |
-| [GESO](geso.qmd) | Gradient-based Evolutionary Structural Optimization |
-| [Local Stress](local_stress.qmd) | Local stress-constrained optimization |
-| [Global Stress](global_stress.qmd) | Global stress-constrained optimization |
-| [Truss](truss.qmd) | Truss topology optimization |
-| [Truss Problems](problems_truss.qmd) | Truss problem types |
-| [Mixed-Integer Truss](mixed_integer_truss.qmd) | MINLP truss design |
-| [Buckling](buckling.qmd) | Buckling-constrained truss optimization |
-| [Heat Sink](heat_sink.qmd) | Thermal compliance optimization |
-| [Heat Tree](heat_tree.qmd) | Tree-shaped heat conduction |
-| [Multi-Material](multimaterial.qmd) | Multi-material topology optimization |
-| [TOBS](tobs.qmd) | Topology Optimization of Binary Structures |
-| [Neural (IPOPT)](neural.qmd) | Neural network parametrization with IPOPT |
-| [Neural (Adam)](neural2.qmd) | Neural network parametrization with Adam |
-| [Continuum Problems](problems_continuum.qmd) | Continuum problem types |
+<!--
+This stub exists only to create a sidebar entry in Documenter.
+It is overwritten by the real Quarto-rendered tutorials/index.html
+during CI assembly (assemble-site job copies docs/tutorials/_site
+into docs/build/tutorials/).
+-->


### PR DESCRIPTION
## Changes

- **Tutorials in sidebar**: Added a 'Tutorials' entry to the Documenter sidebar navigation with a stub `tutorials/index.md` page. The stub is a comment-only placeholder that Documenter uses for the sidebar entry; the CI `assemble-site` job overwrites it with the real Quarto-rendered `index.html`.
- **Local links restored**: Changed tutorial links in `index.md` and `Algorithms.md` from external GitHub Pages URLs back to local relative links pointing at the stub.
- **Clean build**: No `warnonly` workaround needed — all cross-references resolve without warnings.

## Why

The previous PR used external URLs for tutorial links to avoid Documenter's cross-reference validation errors. This restores local links (which work correctly when both Documenter and Quarto outputs are deployed together) and adds tutorials to the left sidebar navigation.