### PR TITLE
Add tutorials link and section to README; clarify AI disclosure rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,14 +159,19 @@ Check what's available first:
 
 ## Devops
 
+- **AI-assistance disclosure (always required).** Every public-facing message
+  produced by an agent — PR body, PR comment, GitHub issue, review, or any
+  other visible post — **must** include a disclosure naming the model and
+  harness/tool, placed at the end of the message:
+
+      *Prepared with assistance from <model> via <tool>.*
+
+  Example: *Prepared with assistance from qwen3.6-plus via opencode.*
+  Never wait to be asked; never omit this. Do not present AI-assisted text
+  as the maintainer's own unaided writing.
 - Do not post comments on GitHub without getting explicit approval for the
   exact text. GitHub is also a social media environment; do not represent the
   maintainer without consent.
-- Any post made on the maintainer's behalf (GitHub issue, PR, comment, review,
-  or other public message) must disclose that it was prepared with assistance
-  from AI and name the model and the harness/tool that produced it (e.g.
-  "Prepared with assistance from GLM-5.2 via opencode"). Do not present
-  AI-assisted text as the maintainer's own unaided writing.
 - Comments, docstrings, and commit messages must stand on their own for a
   reader who has only the repository: state what *is* true about the code now,
   not its history, its motivation, or the plan it came from. Re-read the diff's
@@ -181,5 +186,7 @@ Check what's available first:
   in the body of the commit message; that will trigger GitHub to auto-close the
   issue. If a commit closes multiple issues, you cannot provide ranges or
   comma-separated lists of numbers; use "Fixes #abc; fixes #def; ...".
-- For commits written by agents, use "Assisted-by" rather than
-  "Co-authored-by", and fill in the appropriate model/version/email details.
+- For commits written by agents, include an `Assisted-by:` trailer (not
+  `Co-authored-by:`) with the model and tool details:
+
+      Assisted-by: qwen3.6-plus via opencode

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@
 # TopOpt.jl
 
 [![Actions Status](https://github.com/JuliaTopOpt/TopOpt.jl/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/juliatopopt/TopOpt.jl/actions)
-[![Documentation](https://img.shields.io/badge/doc-latest-blue.svg)](https://juliatopopt.github.io/TopOpt.jl/dev)
+[![Documentation (stable)](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliatopopt.github.io/TopOpt.jl/stable)
+[![Documentation (dev)](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliatopopt.github.io/TopOpt.jl/dev)
 [![codecov](https://codecov.io/gh/juliatopopt/TopOpt.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/juliatopopt/TopOpt.jl)
 
-`TopOpt` is a topology optimization package written in [Julia](https://github.com/JuliaLang/julia). To learn more and see some examples, visit the [documentation](https://juliatopopt.github.io/TopOpt.jl/dev). Numerous examples can also be found in the `test/examples` and `test/wcsmo14` directories.
+`TopOpt` is a topology optimization package written in [Julia](https://github.com/JuliaLang/julia). To learn more and see some examples, visit the [documentation](https://juliatopopt.github.io/TopOpt.jl/stable) ([dev](https://juliatopopt.github.io/TopOpt.jl/dev)) and the [tutorials](https://juliatopopt.github.io/TopOpt.jl/stable/tutorials/) ([dev](https://juliatopopt.github.io/TopOpt.jl/dev/tutorials/)). Numerous examples can also be found in the `test/examples` and `test/wcsmo14` directories.
 
 ## Installation
 
@@ -45,9 +46,7 @@ using TopOpt, Makie, GLMakie
 
 ## Features available
 
-All the following features are available in TopOpt.jl but the documentation is currently lacking! Feel free to open an issue to ask about how to use specific features.
-
-### Optimizaton domains
+### Optimization domains
 
 - 2D and 3D truss domains
 - 2D and 3D continuum domains
@@ -69,7 +68,7 @@ The following high level topology optimization algorithms and penalty types are 
 
 ### Differentiable functions
 
-There are numerous functions in `TopOpt.jl` that are defined in a differentiable way and you can use them in the objectives or constraints in topology optimization formulations. In `TopOpt.jl`, you can build arbitrarily complex objective and constraint functions using these differentiable functions as building blocks or lego pieces chaining them in any arbitrary way. The gradient and jacobian of the aggregate Julia function defined is then obtained using [automatic differentiation](https://www.youtube.com/watch?v=UqymrMG-Qi4). For a detailed account of the functions available, see the relevant section in the [documentation](https://juliatopopt.github.io/TopOpt.jl/dev/functions/).
+There are numerous functions in `TopOpt.jl` that are defined in a differentiable way and you can use them in the objectives or constraints in topology optimization formulations. In `TopOpt.jl`, you can build arbitrarily complex objective and constraint functions using these differentiable functions as building blocks or lego pieces chaining them in any arbitrary way. The gradient and jacobian of the aggregate Julia function defined is then obtained using [automatic differentiation](https://www.youtube.com/watch?v=UqymrMG-Qi4). For a detailed account of the functions available, see the relevant section in the [documentation](https://juliatopopt.github.io/TopOpt.jl/stable/functions/) ([dev](https://juliatopopt.github.io/TopOpt.jl/dev/functions/)).
 
 ### Linear system solvers
 
@@ -99,6 +98,24 @@ We use [Nonconvex.jl](https://github.com/JuliaNonconvex/Nonconvex.jl) for the op
 - End-to-end topology optimization from INP file to VTK file
 - Interactive visualization of designs and deformation using [Makie.jl](https://makie.juliaplots.org/stable/)
 - Interactive visualization of designs using Dash apps and [DashVtk](https://github.com/JuliaTopOpt/DashVtk_Examples/tree/main/src/TopOptDemo)
+
+## Tutorials
+
+The [tutorials](https://juliatopopt.github.io/TopOpt.jl/stable/tutorials/) ([dev](https://juliatopopt.github.io/TopOpt.jl/dev/tutorials/)) cover a wide range of topics with complete, commented examples:
+
+- **SIMP** — basic compliance minimization
+- **BESO / GESO** — evolutionary optimization methods
+- **CSIMP** — continuation SIMP
+- **TOBS** — topology optimization for binary structures
+- **Global / local stress constraints** — stress-constrained design
+- **Heat sink / heat tree** — heat conduction problems
+- **Truss** — truss topology optimization
+- **Buckling** — buckling-constrained optimization
+- **Multi-material** — multi-material design parameterisation
+- **Neural network** — neural-network-based parameterization
+- **Mixed-integer truss** — discrete truss design
+
+See the full list and run the notebooks at [TopOpt Tutorials](https://juliatopopt.github.io/TopOpt.jl/stable/tutorials/) ([dev](https://juliatopopt.github.io/TopOpt.jl/dev/tutorials/)).
 
 ## Citation
 


### PR DESCRIPTION
## Summary

Updates README.md and AGENTS.md:

- **Added stable and dev documentation badges** (replaced single 'doc-latest' badge)
- **Linked to both stable and dev versions** of docs and tutorials in the opening paragraph and Tutorials section
- **Removed outdated 'documentation is lacking' disclaimer** since the docs now cover most features
- **Fixed typo**: 'Optimizaton' → 'Optimization'
- **Added a Tutorials section** listing all available tutorial topics (SIMP, BESO, GESO, CSIMP, TOBS, stress constraints, heat problems, truss, buckling, multi-material, neural network, mixed-integer truss)
- **Clarified AI-assistance disclosure rule** in AGENTS.md as unconditional — every public-facing message must include the model and tool name, with concrete format examples for both posts and commits

---

*Prepared with assistance from qwen3.6-plus via opencode.*