### PR TITLE
Remove test dependency from assemble-site CI job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -161,7 +161,7 @@ jobs:
   # Assemble final site from docs and tutorials artifacts
   assemble-site:
     name: "assemble: Final site"
-    needs: [test, tutorials, docs-build]
+    needs: [tutorials, docs-build]
     if: always() && !cancelled()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The `assemble-site` job only needs the `docs-build` and `tutorials` artifacts. It does not need to wait for the `test` jobs to complete. This allows the docs site to be assembled as soon as the docs and tutorials are rendered, without waiting for the full test suite.

---

*Prepared with assistance from qwen3.6-plus via opencode.*