### PR TITLE
Drop getncells export from TopOpt

### DIFF
--- a/src/TopOpt.jl
+++ b/src/TopOpt.jl
@@ -90,8 +90,6 @@ include(joinpath("TrussTopOptProblems", "TrussTopOptProblems.jl"))
 @reexport using .TrussTopOptProblems
 
 using Ferrite, StaticArrays
-using Ferrite: getncells
-export getncells
 
 using ForwardDiff, IterativeSolvers#, Preconditioners
 @reexport using VTKDataTypes


### PR DESCRIPTION
## What

Small follow-up to #253. The previous PR added `using Ferrite: getncells` and `export getncells` to `src/TopOpt.jl` to work around tutorials missing the import. Drop those two lines; the tutorials and tests import `getncells` directly from `Ferrite` where they need it.

*Prepared with assistance from opencode/minimax-m3 via opencode.*