### PR TITLE
Add light/dark logos to Documenter docs and fix Quarto tutorial logo path

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,8 +7,6 @@ makedocs(;
     sitename="TopOpt.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", nothing) == "true",
-        logo="assets/logo-light.png",
-        logo-dark="assets/logo-dark.png",
     ),
     doctest=true,
     checkdocs=:all,

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,7 +5,11 @@ bib = CitationBibliography(joinpath(@__DIR__, "biblio", "ref.bib"))
 
 makedocs(;
     sitename="TopOpt.jl",
-    format=Documenter.HTML(; prettyurls=get(ENV, "CI", nothing) == "true"),
+    format=Documenter.HTML(;
+        prettyurls=get(ENV, "CI", nothing) == "true",
+        logo="assets/logo-light.png",
+        logo-dark="assets/logo-dark.png",
+    ),
     doctest=true,
     checkdocs=:all,
     plugins=[bib],

--- a/docs/src/assets/logo-dark.png
+++ b/docs/src/assets/logo-dark.png
@@ -1,0 +1,1 @@
+../../../assets/logo-dark.png

--- a/docs/src/assets/logo-light.png
+++ b/docs/src/assets/logo-light.png
@@ -1,0 +1,1 @@
+../../../assets/logo-light.png

--- a/docs/src/assets/logo.png
+++ b/docs/src/assets/logo.png
@@ -1,0 +1,1 @@
+../../../assets/logo-light.png

--- a/docs/tutorials/_quarto.yml
+++ b/docs/tutorials/_quarto.yml
@@ -7,11 +7,11 @@ execute:
 
 website:
   title: "TopOpt.jl"
-  image: "../assets/logo.png"
+  image: "../../assets/logo.png"
   sidebar:
     style: "docked"
     background: light
-    logo: "../assets/logo.png"
+    logo: "../../assets/logo.png"
   navbar:
     right:
       - text: "Back to Docs"


### PR DESCRIPTION
## Changes

- **Documenter docs** (docs/make.jl): Added `logo` (`logo-light.png`) and `logo-dark` options to `Documenter.HTML()` so the logo appears in the docs site with proper light/dark theme support.
- **Symlinks** (docs/src/assets/): Created symlinks to `assets/logo-light.png` and `assets/logo-dark.png` so Documenter can find them (paths are relative to `docs/src/`).
- **Quarto tutorials** (docs/tutorials/_quarto.yml): Fixed broken logo path from `../assets/logo.png` to `../../assets/logo.png` — the previous path resolved to `docs/assets/` which doesn't exist.

*Prepared with assistance from qwen3.6-plus via opencode.*