### PR TITLE
Add logo next to title in docs and tutorial navbar

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,7 @@ using DocumenterCitations
 bib = CitationBibliography(joinpath(@__DIR__, "biblio", "ref.bib"))
 
 makedocs(;
-    sitename="TopOpt.jl",
+    sitename="<img src=\"../assets/logo.png\" alt=\"TopOpt.jl\" style=\"height:1.4em;vertical-align:middle;margin-right:0.4em\">TopOpt.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", nothing) == "true",
     ),

--- a/docs/tutorials/_quarto.yml
+++ b/docs/tutorials/_quarto.yml
@@ -13,6 +13,7 @@ website:
     background: light
     logo: "../../assets/logo.png"
   navbar:
+    logo: "../../assets/logo.png"
     right:
       - text: "Back to Docs"
         href: "../index.html"


### PR DESCRIPTION
Embed the transparent logo inline with the sitename in Documenter and add a navbar logo entry in the Quarto tutorial config.

**Changes:**
- `docs/make.jl`: Added inline `<img>` tag to `sitename` so the logo appears next to "TopOpt.jl" in the Documenter navbar
- `docs/tutorials/_quarto.yml`: Added `logo` under `navbar` so the logo appears next to the title in the Quarto tutorial site

*Prepared with assistance from qwen3.6-plus via opencode.*