### PR TITLE
Fix JET workflow: correct permissions and consolidate to single job

### DIFF
--- a/.github/workflows/JET.yml
+++ b/.github/workflows/JET.yml
@@ -13,14 +13,12 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
-  commits: write
 
 jobs:
-  jet-report-pr:
-    name: "JET: Report vs master"
-    if: github.event_name == 'pull_request'
+  jet-report:
+    name: "JET: Report"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -80,51 +78,15 @@ jobs:
         run: julia --project=test test/jet_compare.jl ../master_jet.json ../pr_jet.json
         working-directory: pr
 
-      - name: Post JET comparison comment
+      - name: Post JET comparison comment (PR)
+        if: github.event_name == 'pull_request'
         uses: thollander/actions-comment-pull-request@v3
         with:
           file: pr/jet_diff.md
           comment_tag: jet-report
 
-  jet-report-master:
-    name: "JET: Report on master"
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          path: master
-
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-          arch: x64
-
-      - uses: julia-actions/cache@v2
-        with:
-          cache-name: jet-report
-          cache-artifacts: true
-          cache-packages: true
-          cache-compiled: true
-
-      - name: Use General git registry
-        run: |
-          rm -rf ~/.julia/registries/General.toml ~/.julia/registries/General.tar.gz
-          julia -e 'using Pkg; Pkg.Registry.add(RegistrySpec(url="https://github.com/JuliaRegistries/General.git"))'
-
-      - name: Instantiate master environment
-        run: |
-          julia --project=master/test -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path="master"))
-            Pkg.instantiate()
-            Pkg.precompile()'
-
-      - name: Run JET on master
-        run: julia --project=test test/jet_report.jl --output ../master_jet.json
-        working-directory: master
-
-      - name: Post JET report comment
+      - name: Post JET report comment (push to master)
+        if: github.event_name == 'push'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Problem

The JET Report workflow was not triggering because `commits: write` is not a valid GitHub Actions permission, causing GitHub to fail parsing the workflow file.

## Fix

1. Changed `commits: write` to `contents: write` (the correct permission for posting commit comments)
2. Consolidated `jet-report-pr` and `jet-report-master` into a single `jet-report` job that checks `github.event_name` to determine the behavior:
   - On `pull_request`: compares PR vs master, posts diff as PR comment
   - On `push` to master: runs JET on master, posts full report as commit comment

*Prepared with assistance from qwen3.6-plus via opencode.*