### PR TITLE
Fix JET workflow: correct path to master_jet.json

### DIFF
--- a/.github/workflows/JET.yml
+++ b/.github/workflows/JET.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const report = JSON.parse(fs.readFileSync('master/master_jet.json', 'utf8'));
+            const report = JSON.parse(fs.readFileSync('master_jet.json', 'utf8'));
             const lines = [
               '### JET Report (master)',
               '',


### PR DESCRIPTION
The `Post JET report comment (push to master)` step reads `master_jet.json` from the wrong path. The JET report script writes the file to the runner working directory (`../master_jet.json` relative to the `master/` checkout), not inside `master/master_jet.json`.

Fix: read from `master_jet.json` instead of `master/master_jet.json`.

*Prepared with assistance from qwen3.6-plus via opencode.*