### PR TITLE
Fix GESO validation tests and add missing tutorials to index

### DIFF
--- a/docs/tutorials/index.qmd
+++ b/docs/tutorials/index.qmd
@@ -92,6 +92,20 @@ Softmax parametrization for distributing 3+ candidate materials with mass constr
 6-layer MLP with Adam optimizer and continuation on penalty and constraint aggregation weight.
 :::
 
+## Truss optimization
+
+::: {.tutorial-card}
+**[Truss Topology Optimization](truss.html)**
+
+Compliance minimization on bar structures with JSON-defined geometry, power-law penalization, and MMA87 optimizer.
+:::
+
+::: {.tutorial-card}
+**[Mixed-Integer Truss Optimization](mixed_integer_truss.html)**
+
+Binary (0/1) truss design via Juniper.jl branch-and-bound with IPOPT relaxation — crisp layouts with no intermediate densities.
+:::
+
 ## Problem types
 
 ::: {.tutorial-card}

--- a/test/Algorithms/test_geso.jl
+++ b/test/Algorithms/test_geso.jl
@@ -340,16 +340,16 @@ using Ferrite: getncells
         x0 = fill(0.5, length(solver.vars))
 
         black_wrong = falses(nel + 5)
-        @test_throws AssertionError geso(x0; black=black_wrong, seed=100)
+        @test_throws DimensionMismatch geso(x0; black=black_wrong, seed=100)
 
         white_wrong = falses(nel + 5)
-        @test_throws AssertionError geso(x0; white=white_wrong, seed=101)
+        @test_throws DimensionMismatch geso(x0; white=white_wrong, seed=101)
 
         black_overlap = falses(nel)
         white_overlap = falses(nel)
         black_overlap[1:3] .= true
         white_overlap[1:3] .= true
-        @test_throws AssertionError geso(
+        @test_throws ArgumentError geso(
             x0; black=black_overlap, white=white_overlap, seed=102
         )
     end


### PR DESCRIPTION
Two independent fixes:

1. **GESO validation tests** — Tests expected `AssertionError` but the implementation throws more descriptive error types:
   - `DimensionMismatch` for wrong-length `black`/`white` vectors
   - `ArgumentError` for overlapping `black`/`white` elements

2. **Missing tutorial links** — Added `truss.html` and `mixed_integer_truss.html` to the tutorial landing page. These tutorial files existed but were not linked from the index.

*Prepared with assistance from qwen3.6-plus via opencode.*