### PR TITLE
Embed CSS resources in tutorial HTML output

### DIFF
--- a/docs/tutorials/_quarto.yml
+++ b/docs/tutorials/_quarto.yml
@@ -24,3 +24,4 @@ format:
     toc: true
     toc-location: left
     css: topopt-tutorials.css
+    embed-resources: true


### PR DESCRIPTION
Fixes missing CSS on deployed tutorial site by inlining resources into each HTML file.

*Prepared with assistance from qwen3.6-plus via opencode.*