### PR TITLE
Write nodal temperature in save_mesh for heat problems

### DIFF
--- a/src/TopOptProblems/IO/VTK.jl
+++ b/src/TopOptProblems/IO/VTK.jl
@@ -62,6 +62,22 @@ function save_mesh(filename::AbstractString, problem::HeatTransferTopOptProblem)
     return outfiles = WriteVTK.vtk_save(vtkfile)
 end
 
+"""
+    save_mesh(filename, problem::HeatTransferTopOptProblem, vars, temperature)
+
+Save the design topology and the nodal `temperature` field (e.g. from
+[`TemperatureFun`](@ref)) as a VTK (.vtu) mesh file.
+"""
+function save_mesh(
+    filename::AbstractString,
+    problem::HeatTransferTopOptProblem,
+    vars::AbstractVector,
+    temperature::AbstractVector,
+)
+    vtkfile = WriteVTK.vtk_grid(filename, problem, vars, temperature)
+    return outfiles = WriteVTK.vtk_save(vtkfile)
+end
+
 function WriteVTK.vtk_grid(
     filename::AbstractString,
     problem::HeatTransferTopOptProblem{dim,T},
@@ -88,6 +104,24 @@ function WriteVTK.vtk_grid(
     end
     coords = reshape(reinterpret(T, Ferrite.getnodes(grid)), (dim, Ferrite.getnnodes(grid)))
     return vtk_grid(filename, coords, cls)
+end
+
+function WriteVTK.vtk_grid(
+    filename::AbstractString,
+    problem::HeatTransferTopOptProblem{dim,T},
+    ρ::AbstractVector{T},
+    temperature::AbstractVector,
+) where {dim,T}
+    grid = problem.ch.dh.grid
+    nnodes = Ferrite.getnnodes(grid)
+    length(temperature) == nnodes || throw(
+        DimensionMismatch(
+            "Temperature vector must have length equal to number of nodes ($nnodes), got $(length(temperature))",
+        ),
+    )
+    vtkfile = WriteVTK.vtk_grid(filename, problem, ρ)
+    WriteVTK.vtk_point_data(vtkfile, temperature, "temperature")
+    return vtkfile
 end
 
 end

--- a/test/topopt_problems/test_io.jl
+++ b/test/topopt_problems/test_io.jl
@@ -113,6 +113,28 @@ end
             @test any(f -> occursin("test_heat", f), files)
         end
 
+        @testset "Heat problem VTK export with temperature" begin
+            nels = (4, 4)
+            problem = HeatConductionProblem(
+                nels, (1.0, 1.0), 1.0; Tleft=0.0, Tright=0.0, heatflux=Dict("top" => 1.0)
+            )
+            solver = FEASolver(DirectSolver, problem; xmin=0.01)
+            tf = TemperatureFun(solver)
+            T = tf(PseudoDensities(ones(prod(nels))))
+            vtk_path = joinpath(tmpdir, "test_heat_temp")
+
+            @test_nowarn TopOpt.TopOptProblems.InputOutput.save_mesh(
+                vtk_path, problem, solver.vars, T
+            )
+            files = readdir(tmpdir)
+            @test any(f -> occursin("test_heat_temp", f), files)
+
+            # A temperature field of the wrong length fails fast.
+            @test_throws DimensionMismatch TopOpt.TopOptProblems.InputOutput.save_mesh(
+                vtk_path * "_bad", problem, solver.vars, zeros(3)
+            )
+        end
+
         @testset "VTK with cell data" begin
             problem = PointLoadCantilever((4, 4), (1.0, 1.0), 1.0, 0.3, 1.0)
             vtk_path = joinpath(tmpdir, "test_with_data")


### PR DESCRIPTION
## Summary

Completes the mesh-writing half of #205. `save_mesh` for `HeatTransferTopOptProblem` can now write the nodal temperature field alongside the topology.

- New `save_mesh(filename, problem::HeatTransferTopOptProblem, vars, temperature)` method.
- `WriteVTK.vtk_grid(..., ρ, temperature)` adds the nodal temperature as VTK point data (`"temperature"`).
- Fails fast with `DimensionMismatch` if the temperature length doesn't match the number of nodes.
- Works with the output of `TemperatureFun` (a `TemperatureResult` is an `AbstractVector`).

### Usage
```julia
problem = HeatConductionProblem((60, 20), (1.0, 1.0), 1.0; heatflux=Dict("top" => 100.0))
solver = FEASolver(DirectSolver, problem; xmin=0.001)
T = TemperatureFun(solver)(PseudoDensities(ones(length(solver.vars))))
save_mesh("heat.vtu", problem, solver.vars, T)
```

### Verification
- `test/topopt_problems/test_io.jl` extended with a temperature-export test (passes).
- Formatted with JuliaFormatter 2.x BlueStyle.

*Prepared with assistance from deepseek-v4-pro via opencode.*