### PR TITLE
Document all exported TopOpt features; simplify JET report comment

### DIFF
--- a/.github/workflows/JET.yml
+++ b/.github/workflows/JET.yml
@@ -74,11 +74,11 @@ jobs:
         run: julia --project=test test/jet_report.jl --output ../master_jet.json
         working-directory: master
 
-      - name: Compare JET reports
+      - name: Compare JET reports (PR)
         run: julia --project=test test/jet_compare.jl ../master_jet.json ../pr_jet.json
         working-directory: pr
 
-      - name: Compare JET reports (full, for master push)
+      - name: List JET issues (push to master)
         if: github.event_name == 'push'
         run: julia --project=test test/jet_compare.jl ../master_jet.json ../pr_jet.json --full
         working-directory: pr

--- a/docs/src/functions.md
+++ b/docs/src/functions.md
@@ -54,6 +54,21 @@ Every differentiable callable struct type uses a `Fun` suffix in its name (e.g. 
   - **Constructor example**: `disp = DisplacementFun(solver)`
   - **Usage example**: `u = disp(x)`
 
+## Nodal temperature
+  - **Function name**: `TemperatureFun`
+  - **Description**: Nodal temperature function for heat-conduction problems. Solves the thermal FEA system and returns the temperature at every node, analogous to `DisplacementFun` for linear elasticity. Works with homogeneous and inhomogeneous (prescribed) temperature boundary conditions.
+  - **Input(s)**: Filtered and optionally projected design `x::PseudoDensities`
+  - **Output**: Nodal temperature `T::TemperatureResult`
+  - **Constructor example**: `tf = TemperatureFun(solver)`
+  - **Usage example**: `T = tf(PseudoDensities(x))`
+
+## Cell-averaged temperature
+  - **Function name**: `cell_temperature`
+  - **Description**: Averages a nodal temperature field over each cell's nodes to produce a per-cell temperature vector, suitable for coloring a heat-problem visualization with `visualize(problem; cell_colors=...)`.
+  - **Input(s)**: A `TemperatureResult` (or plain vector) and a `HeatTransferTopOptProblem`
+  - **Output**: Per-cell temperature `::Vector{<:Real}`
+  - **Usage example**: `cellT = cell_temperature(T, problem)`
+
 ## Element-wise microscopic stress tensor
   - **Function name**: `StressTensorFun`
   - **Description**: A function computing the element-wise microscopic stress tensor which is useful in stress-constrained optimization and machine learning for topology optimization. The microscopic stress tensor uses the base Young's modulus to compute the stiffness tensor and calculate the stress tensor from the strain tensor.

--- a/docs/src/reference/FEA.md
+++ b/docs/src/reference/FEA.md
@@ -55,3 +55,9 @@ EnergyCriteria
 ```@docs
 simulate
 ```
+
+## Internal CG solve
+
+```@docs
+cg_solve!
+```

--- a/docs/src/reference/Functions.md
+++ b/docs/src/reference/Functions.md
@@ -9,6 +9,12 @@ docstrings.
 CurrentModule = TopOpt.Functions
 ```
 
+## Abstract type
+
+```@docs
+AbstractFunction
+```
+
 ## ComplianceFun and volume
 
 ```@docs
@@ -30,6 +36,21 @@ epsilon_relaxed
 TrussStressFun
 ```
 
+## Temperature
+
+```@docs
+TemperatureFun
+cell_temperature
+```
+
+## Multi-load and trace estimation
+
+```@docs
+generate_scenarios
+hutch_rand!
+hadamard!
+```
+
 ## Buckling helpers
 
 ```@docs
@@ -46,6 +67,10 @@ TrussElementKσFun
 NeuralNetworkFun
 TrainFunctionFun
 PredictFunctionFun
+AbstractMLModel
+Coordinates
+NNParams
+getcentroids
 ```
 
 ## Multi-material

--- a/docs/src/reference/TopOptProblems.md
+++ b/docs/src/reference/TopOptProblems.md
@@ -8,6 +8,10 @@ CurrentModule = TopOpt.TopOptProblems
 
 ## Problem types
 
+```@docs
+AbstractTopOptProblem
+```
+
 ### Structural problems
 
 `StiffnessTopOptProblem` is an abstract type that a number of linear elasticity, quasi-static, topology optimization problems subtype.
@@ -79,12 +83,50 @@ RectilinearGrid
 LGrid
 ```
 
+```@docs
+TieBeamGrid
+```
+
+## Problem accessors
+
+The following accessors are available on every problem type (structural and
+heat transfer):
+
+```@docs
+getdim
+floattype
+getdh
+getk
+getcloaddict
+getfacesets
+getpressuredict
+getheatfluxdict
+```
+
+## Material accessors
+
+```@docs
+YoungsModulus
+PoissonRatio
+```
+
+## Mesh output
+
+```@docs
+save_mesh
+```
+
 ## Finite element backend
 
 Currently, `TopOpt` uses [`Ferrite.jl`](https://github.com/KristofferC/Ferrite.jl) for FEA-related modeling. 
 This means that all the problems above are described in the language and types of `Ferrite`.
 
 ## Matrices and vectors
+
+```@docs
+assemble
+assemble_f!
+```
 
 ### `ElementFEAInfo`
 

--- a/docs/src/reference/Utilities.md
+++ b/docs/src/reference/Utilities.md
@@ -47,3 +47,15 @@ setpenalty!
 ```@docs
 density
 ```
+
+## Low-level helpers
+
+```@docs
+RaggedArray
+compliance
+sumdiag
+meandiag
+getsolver
+@debug
+@forward_property
+```

--- a/src/FEA/solvers_api.jl
+++ b/src/FEA/solvers_api.jl
@@ -168,6 +168,12 @@ end
 # `solve_system!` methods (forward pass) and by the thermal adjoint
 # `solve_adjoint!` in `Functions` so the CG setup (preconditioner init, lhs
 # zeroing, and the `cg!` call) is written once.
+"""
+    cg_solve!(solver, op, rhs, lhs, precond_matrix; initially_zero=true)
+
+Solve the linear system with the solver's preconditioned conjugate-gradient
+settings, writing the solution into `lhs`.
+"""
 function cg_solve!(
     solver::GenericFEASolver{T,Physics,Solver},
     op,

--- a/src/Functions/Functions.jl
+++ b/src/Functions/Functions.jl
@@ -54,6 +54,13 @@ export VolumeFun,
     get_free_variables,
     get_free_variable_count
 
+"""
+    AbstractFunction{T}
+
+Abstract supertype for all differentiable objective/constraint functions in
+`TopOpt` (e.g. [`ComplianceFun`](@ref), [`VolumeFun`](@ref)). The parameter `T`
+is the number type of the function's inputs and outputs.
+"""
 abstract type AbstractFunction{T} <: Nonconvex.NonconvexCore.AbstractFunction end
 
 include("compliance.jl")

--- a/src/Functions/mean_compliance.jl
+++ b/src/Functions/mean_compliance.jl
@@ -140,6 +140,12 @@ end
 Utilities.getpenalty(c::MeanComplianceFun) = getpenalty(getsolver(c.compliance))
 @forward_property MeanComplianceFun compliance
 
+"""
+    hutch_rand!(x::Array)
+
+Fill `x` with independent Rademacher (±1) samples, used by the Hutchinson
+trace estimator in [`MeanComplianceFun`](@ref).
+"""
 hutch_rand!(x::Array) = x .= rand.(Ref(-1.0:2.0:1.0))
 function hadamard3!(V)
     n, nv = size(V)
@@ -170,6 +176,12 @@ function hadamard2!(V)
     V .= H[1:n, :]
     return V
 end
+"""
+    hadamard!(V)
+
+Fill `V` with Hadamard (±1) columns, used by the Hadamard-based trace estimator
+in [`MeanComplianceFun`](@ref).
+"""
 function hadamard!(V)
     n, nv = size(V)
     H = ones(Int, 1, 1)
@@ -182,6 +194,14 @@ function hadamard!(V)
     return V
 end
 
+"""
+    generate_scenarios(dof::Int, size::Tuple{Int,Int}, f, perturb=() -> (rand() - 0.5))
+
+Generate a sparse load matrix `F` of shape `size` for the single degree of
+freedom `dof`, with load magnitudes `f` perturbed by `perturb`. Used to build
+the multi-load scenarios of a [`MeanComplianceFun`](@ref) /
+[`BlockComplianceFun`](@ref).
+"""
 function generate_scenarios(dof::Int, size::Tuple{Int,Int}, f, perturb=() -> (rand() - 0.5))
     ndofs, nscenarios = size
     I = Int[]

--- a/src/Functions/neural.jl
+++ b/src/Functions/neural.jl
@@ -1,10 +1,28 @@
+"""
+    Coordinates(coords)
+
+Wrapper for the centroid coordinates of the elements, used as the input to the
+neural-network model in [`NeuralNetworkFun`](@ref).
+"""
 struct Coordinates{C}
     coords::C
 end
+
+"""
+    NNParams(p)
+
+Wrapper for the neural network's weights and biases `p`, the design variables
+of a neural-network-parametrized topology optimization.
+"""
 struct NNParams{W}
     p::W
 end
 
+"""
+    getcentroids(problem::AbstractTopOptProblem)
+
+Return a vector of the element centroid coordinates for `problem`.
+"""
 function getcentroids(problem::AbstractTopOptProblem)
     dh = problem.ch.dh
     return map(CellIterator(dh)) do cell
@@ -12,6 +30,12 @@ function getcentroids(problem::AbstractTopOptProblem)
     end
 end
 
+"""
+    AbstractMLModel
+
+Abstract supertype for machine-learning models that re-parametrize the design
+(e.g. [`NeuralNetworkFun`](@ref)).
+"""
 abstract type AbstractMLModel end
 
 """

--- a/src/TopOptProblems/IO/INP/inpstiffness.jl
+++ b/src/TopOptProblems/IO/INP/inpstiffness.jl
@@ -1,4 +1,6 @@
 """
+    InpStiffness{dim, N, TF, TI, Tch, GO, TInds, TMeta} <: StiffnessTopOptProblem{dim, TF}
+
 A problem defined by an imported Abaqus `.inp` file, with arbitrary
 unstructured mesh, boundary conditions, and loads.
 

--- a/src/TopOptProblems/IO/INP/inpstiffness.jl
+++ b/src/TopOptProblems/IO/INP/inpstiffness.jl
@@ -1,4 +1,7 @@
 """
+A problem defined by an imported Abaqus `.inp` file, with arbitrary
+unstructured mesh, boundary conditions, and loads.
+
 ```
 struct InpStiffness{dim, N, TF, TI, Tch <: ConstraintHandler, GO, TInds <: AbstractVector{TI}, TMeta<:Metadata} <: StiffnessTopOptProblem{dim, TF}
     inp_content::InpContent{dim, TF, N, TI}

--- a/src/TopOptProblems/IO/VTK.jl
+++ b/src/TopOptProblems/IO/VTK.jl
@@ -25,6 +25,11 @@ function save_mesh(filename::AbstractString, alg)
     vars = alg.optimizer.obj.solver.vars
     return save_mesh(filename, problem, vars)
 end
+"""
+    save_mesh(filename, problem, vars)
+
+Save the design `vars` (a density vector) as a VTK (.vtu) mesh file.
+"""
 function save_mesh(filename::AbstractString, problem, vars::AbstractVector)
     vtkfile = WriteVTK.vtk_grid(filename, problem, vars)
     return outfiles = WriteVTK.vtk_save(vtkfile)
@@ -66,7 +71,7 @@ end
     save_mesh(filename, problem::HeatTransferTopOptProblem, vars, temperature)
 
 Save the design topology and the nodal `temperature` field (e.g. from
-[`TemperatureFun`](@ref)) as a VTK (.vtu) mesh file.
+`TemperatureFun`) as a VTK (.vtu) mesh file.
 """
 function save_mesh(
     filename::AbstractString,

--- a/src/TopOptProblems/TopOptProblems.jl
+++ b/src/TopOptProblems/TopOptProblems.jl
@@ -11,6 +11,15 @@ using VTKDataTypes
 
 import Ferrite: assemble!
 
+"""
+    AbstractTopOptProblem
+
+Abstract supertype for all topology optimization problems (continuum
+`StiffnessTopOptProblem`, `HeatTransferTopOptProblem`, and truss
+`TrussProblem`). Every concrete subtype provides a `Ferrite.ConstraintHandler`
+(`ch`), element metadata, and the accessors in this module (`getdim`, `getdh`,
+`getncells`, ...).
+"""
 abstract type AbstractTopOptProblem end
 
 include("grids.jl")

--- a/src/TopOptProblems/assemble.jl
+++ b/src/TopOptProblems/assemble.jl
@@ -1,3 +1,9 @@
+"""
+    assemble(problem, elementinfo, vars, penalty, xmin)
+
+Assemble the global stiffness matrix and load vector of `problem` from the
+element information and design variables, returning a [`GlobalFEAInfo`](@ref).
+"""
 function assemble(
     problem::AbstractTopOptProblem,
     elementinfo::ElementFEAInfo,
@@ -96,6 +102,12 @@ function assemble_f(
 end
 get_f(problem, vars::Array) = zeros(floattype(problem), ndofs(problem.ch.dh))
 
+"""
+    assemble_f!(f, problem, elementinfo, ρ, penalty, xmin)
+
+Assemble the global load vector `f` in place from the element load vectors and
+concentrated/distributed loads.
+"""
 function assemble_f!(
     f::AbstractVector,
     problem::StiffnessTopOptProblem,

--- a/src/TopOptProblems/grids.jl
+++ b/src/TopOptProblems/grids.jl
@@ -627,6 +627,13 @@ function _QuadraticLGrid(
     return Grid(cells, nodes; facetsets=facesets, nodesets=nodesets)
 end
 
+"""
+    TieBeamGrid(::Type{T}=Float64; celltype=:Linear, refine=1)
+
+Construct the [`TieBeam`](@ref) grid — the standard 2D tie-beam benchmark mesh.
+`refine` controls the mesh refinement (a value of 1 gives the standard
+literature problem), and `celltype` selects `:Linear` or `:Quadratic` elements.
+"""
 function TieBeamGrid((::Type{T})=Float64; celltype::Symbol=:Linear, refine=1) where {T}
     return _TieBeamGrid(_celltype_tag(celltype), T, refine)
 end

--- a/src/TopOptProblems/problem_types.jl
+++ b/src/TopOptProblems/problem_types.jl
@@ -73,6 +73,8 @@ getfacesets(p::StiffnessTopOptProblem{dim,T}) where {dim,T} = Dict{String,Tuple{
 Ferrite.getncells(problem::StiffnessTopOptProblem) = Ferrite.getncells(getdh(problem).grid)
 
 """
+    PointLoadCantilever{dim, T, N, M} <: StiffnessTopOptProblem{dim, T}
+
 A cantilever beam problem with a point load applied at the free end. Available
 in 2D and 3D.
 
@@ -229,6 +231,8 @@ function _PointLoadCantilever(
 end
 
 """
+    HalfMBB{dim, T, N, M} <: StiffnessTopOptProblem{dim, T}
+
 The half Messerschmitt-Bölkow-Blohm (MBB) beam problem with a point load at
 the top-left corner. Available in 2D and 3D.
 
@@ -398,6 +402,8 @@ function getcloaddict(p::Union{PointLoadCantilever{dim,T},HalfMBB{dim,T}}) where
 end
 
 """
+    LBeam{T, N, M} <: StiffnessTopOptProblem{2, T}
+
 An L-shaped beam problem with a point load at the free end of the lower slab.
 Always 2D.
 
@@ -611,6 +617,8 @@ function getcloaddict(p::LBeam{T}) where {T}
 end
 
 """
+    TieBeam{T, N, M} <: StiffnessTopOptProblem{2, T}
+
 A tie-beam problem with distributed loading on specified elements. Always 2D.
 
 ```

--- a/src/TopOptProblems/problem_types.jl
+++ b/src/TopOptProblems/problem_types.jl
@@ -10,22 +10,72 @@ An abstract stiffness topology optimization problem. All subtypes must have the 
 abstract type StiffnessTopOptProblem{dim,T} <: AbstractTopOptProblem end
 
 # Fallbacks
+"""
+    getdim(problem::StiffnessTopOptProblem)
+
+Return the spatial dimension of the problem.
+"""
 getdim(::StiffnessTopOptProblem{dim,T}) where {dim,T} = dim
+
+"""
+    floattype(problem::StiffnessTopOptProblem)
+
+Return the number type used for the problem's coordinates and computations.
+"""
 floattype(::StiffnessTopOptProblem{dim,T}) where {dim,T} = T
 getE(p::StiffnessTopOptProblem) = p.E
 getν(p::StiffnessTopOptProblem) = p.ν
+
+"""
+    YoungsModulus(p::StiffnessTopOptProblem)
+
+Return the Young's modulus of a structural topology optimization problem.
+"""
 YoungsModulus(p::StiffnessTopOptProblem) = getE(p)
+
+"""
+    PoissonRatio(p::StiffnessTopOptProblem)
+
+Return the Poisson's ratio of a structural topology optimization problem.
+"""
 PoissonRatio(p::StiffnessTopOptProblem) = getν(p)
 getgeomorder(p::StiffnessTopOptProblem) = nnodespercell(p) in (9, 27) ? 2 : 1
 getdensity(::StiffnessTopOptProblem{dim,T}) where {dim,T} = T(0)
 getmetadata(p::StiffnessTopOptProblem) = p.metadata
+
+"""
+    getdh(problem::StiffnessTopOptProblem)
+
+Return the `Ferrite.DofHandler` of the problem.
+"""
 getdh(p::StiffnessTopOptProblem) = p.ch.dh
+
+"""
+    getcloaddict(problem::StiffnessTopOptProblem)
+
+Return the concentrated-load dictionary (node index => load vector).
+"""
 getcloaddict(p::StiffnessTopOptProblem{dim,T}) where {dim,T} = Dict{String,Vector{T}}()
+
+"""
+    getpressuredict(problem::StiffnessTopOptProblem)
+
+Return the pressure-load dictionary (faceset name => pressure value).
+"""
 getpressuredict(p::StiffnessTopOptProblem{dim,T}) where {dim,T} = Dict{String,T}()
+
+"""
+    getfacesets(problem::StiffnessTopOptProblem)
+
+Return the face sets of the problem's grid.
+"""
 getfacesets(p::StiffnessTopOptProblem{dim,T}) where {dim,T} = Dict{String,Tuple{Int,T}}()
 Ferrite.getncells(problem::StiffnessTopOptProblem) = Ferrite.getncells(getdh(problem).grid)
 
 """
+A cantilever beam problem with a point load applied at the free end. Available
+in 2D and 3D.
+
 ```
 ///**********************************
 ///*                                *
@@ -179,6 +229,9 @@ function _PointLoadCantilever(
 end
 
 """
+The half Messerschmitt-Bölkow-Blohm (MBB) beam problem with a point load at
+the top-left corner. Available in 2D and 3D.
+
 ```
  |
  |
@@ -345,6 +398,9 @@ function getcloaddict(p::Union{PointLoadCantilever{dim,T},HalfMBB{dim,T}}) where
 end
 
 """
+An L-shaped beam problem with a point load at the free end of the lower slab.
+Always 2D.
+
 ```
 ////////////
 ............
@@ -555,6 +611,8 @@ function getcloaddict(p::LBeam{T}) where {T}
 end
 
 """
+A tie-beam problem with distributed loading on specified elements. Always 2D.
+
 ```
                                                                1
                                                                
@@ -688,10 +746,22 @@ abstract type HeatTransferTopOptProblem{dim,T} <: AbstractTopOptProblem end
 # Fallbacks for HeatTransferTopOptProblem
 getdim(::HeatTransferTopOptProblem{dim,T}) where {dim,T} = dim
 floattype(::HeatTransferTopOptProblem{dim,T}) where {dim,T} = T
+
+"""
+    getk(problem::HeatTransferTopOptProblem)
+
+Return the thermal conductivity of a heat transfer problem.
+"""
 getk(p::HeatTransferTopOptProblem) = p.k
 getmetadata(p::HeatTransferTopOptProblem) = p.metadata
 getdh(p::HeatTransferTopOptProblem) = p.ch.dh
 getpressuredict(p::HeatTransferTopOptProblem{dim,T}) where {dim,T} = Dict{String,T}()
+
+"""
+    getheatfluxdict(problem::HeatTransferTopOptProblem)
+
+Return the surface heat-flux dictionary (faceset name => heat flux value).
+"""
 getheatfluxdict(p::HeatTransferTopOptProblem{dim,T}) where {dim,T} = Dict{String,T}()
 getfacesets(p::HeatTransferTopOptProblem) = getdh(p).grid.facetsets
 function Ferrite.getncells(problem::HeatTransferTopOptProblem)

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -45,6 +45,12 @@ Update the penalty of `solver` to `p` (a number or an `AbstractPenalty`).
 Stashes the old penalty in `getprevpenalty`.
 """
 function setpenalty! end
+"""
+    getsolver(f)
+
+Return the solver wrapped by `f` (a function or algorithm that stores its
+solver in the `solver` field).
+"""
 getsolver(f) = f.solver
 
 # Utilities

--- a/src/Utilities/utils.jl
+++ b/src/Utilities/utils.jl
@@ -1,3 +1,10 @@
+"""
+    RaggedArray(vv::Vector{Vector{T}})
+
+Store a vector of variable-length vectors in a single flat `values` array with
+an `offsets` array marking where each row begins. Used to pack the per-cell
+DOF and cell connectivity tables of the FEA metadata.
+"""
 struct RaggedArray{TO,TV}
     offsets::TO
     values::TV
@@ -32,6 +39,11 @@ function Base.setindex!(ra::RaggedArray, v, i, j)
     return ra.values[r[i]] = v
 end
 
+"""
+    compliance(Ke, u, dofs)
+
+Compute the local compliance `uᵀ Ke u` over the degrees of freedom `dofs`.
+"""
 function compliance(Ke, u, dofs)
     comp = zero(eltype(u))
     for i in eachindex(dofs)
@@ -42,6 +54,11 @@ function compliance(Ke, u, dofs)
     return comp
 end
 
+"""
+    meandiag(K::AbstractMatrix)
+
+Compute the mean of the absolute diagonal entries of `K`.
+"""
 function meandiag(K::AbstractMatrix)
     z = zero(eltype(K))
     for i in axes(K, 1)
@@ -59,6 +76,11 @@ Map a design variable `var` ∈ [0, 1] to a physical density in `[xmin, 1]`:
 """
 density(var, xmin) = var * (1 - xmin) + xmin
 
+"""
+    @debug expr
+
+Evaluate `expr` only when the package-level `DEBUG` flag is enabled.
+"""
 macro debug(expr)
     return quote
         if DEBUG[]
@@ -75,6 +97,12 @@ end
     f ∈ fieldnames(T) && return :(setfield!(c, $(QuoteNode(f)), val))
     return :(setproperty!(getfield(c, $(QuoteNode(fallback))), $(QuoteNode(f)), val))
 end
+"""
+    @forward_property T field
+
+Forward any `getproperty`/`setproperty!` access on `T` to its `field`, so
+`T` transparently exposes that field's properties.
+"""
 macro forward_property(T, field)
     quote
         function Base.getproperty(c::$(esc(T)), f::Symbol)

--- a/test/jet_compare.jl
+++ b/test/jet_compare.jl
@@ -1,12 +1,13 @@
 using JSON
 
-# Read two JET JSON reports and produce a markdown diff.
+# Produce the JET markdown comment.
 # Usage: julia jet_compare.jl master.json pr.json [--full]
-# With --full, also lists all issues on master and PR. Without it, only the diff.
+#   Without --full (PR): a Master/PR comparison table plus new/fixed issues.
+#   With --full (push to master): just the current issues, or a "no issues" note.
 
 master_file = ARGS[1]
 pr_file = ARGS[2]
-full_report = "--full" in ARGS
+list_mode = "--full" in ARGS
 
 master = JSON.parsefile(master_file)
 pr = JSON.parsefile(pr_file)
@@ -18,134 +19,90 @@ end
 master_issues = Dict(issue_key(i) => i for i in master["issues"])
 pr_issues = Dict(issue_key(i) => i for i in pr["issues"])
 
-new_issues = [
-    i for k in keys(pr_issues) if !haskey(master_issues, k) for i in [pr_issues[k]]
-]
-fixed_issues = [
-    i for k in keys(master_issues) if !haskey(pr_issues, k) for i in [master_issues[k]]
-]
-
-# Sort by file for readability
-sort!(new_issues; by=i -> i["signature"])
-sort!(fixed_issues; by=i -> i["signature"])
-
-master_total = master["total_issues"]
-pr_total = pr["total_issues"]
-master_errors = master["errors"]
-pr_errors = pr["errors"]
-master_warnings = master["warnings"]
-pr_warnings = pr["warnings"]
+function issue_block(i, issue)
+    sig = issue["signature"]
+    msg = issue["message"]
+    if length(msg) > 500
+        msg = msg[1:500] * "…"
+    end
+    return [
+        "<details><summary>$(i). $(issue["type"]) — $(basename(sig))</summary>",
+        "",
+        "```",
+        msg,
+        "```",
+        "</details>",
+        "",
+    ]
+end
 
 lines = String[]
-push!(lines, "### JET Report Comparison")
-push!(lines, "")
-push!(lines, "| | Master | PR | Δ |")
-push!(lines, "|---|---|---|---|")
-push!(
-    lines, "| Total issues | $(master_total) | $(pr_total) | $(pr_total - master_total) |"
-)
-push!(lines, "| Errors | $(master_errors) | $(pr_errors) | $(pr_errors - master_errors) |")
-push!(
-    lines,
-    "| Warnings | $(master_warnings) | $(pr_warnings) | $(pr_warnings - master_warnings) |",
-)
-push!(lines, "")
 
-if !isempty(new_issues)
-    push!(lines, "#### ⚠️ New issues ($(length(new_issues)))")
+if list_mode
+    issues = sort(collect(values(pr_issues)); by=i -> i["signature"])
+    push!(lines, "### JET Report")
     push!(lines, "")
-    for (i, issue) in enumerate(new_issues)
-        sig = issue["signature"]
-        msg = issue["message"]
-        # Truncate long messages
-        if length(msg) > 500
-            msg = msg[1:500] * "…"
+    if isempty(issues)
+        push!(lines, "No JET issues found.")
+    else
+        push!(lines, "$(length(issues)) issue(s):")
+        push!(lines, "")
+        for (i, issue) in enumerate(issues)
+            append!(lines, issue_block(i, issue))
         end
-        push!(
-            lines, "<details><summary>$(i). $(issue["type"]) — $(basename(sig))</summary>"
-        )
-        push!(lines, "")
-        push!(lines, "```")
-        push!(lines, msg)
-        push!(lines, "```")
-        push!(lines, "</details>")
-        push!(lines, "")
     end
-end
+else
+    new_issues = [
+        i for k in keys(pr_issues) if !haskey(master_issues, k) for i in [pr_issues[k]]
+    ]
+    fixed_issues = [
+        i for k in keys(master_issues) if !haskey(pr_issues, k) for i in [master_issues[k]]
+    ]
+    sort!(new_issues; by=i -> i["signature"])
+    sort!(fixed_issues; by=i -> i["signature"])
 
-if !isempty(fixed_issues)
-    push!(lines, "#### ✅ Fixed issues ($(length(fixed_issues)))")
+    master_total = master["total_issues"]
+    pr_total = pr["total_issues"]
+    master_errors = master["errors"]
+    pr_errors = pr["errors"]
+    master_warnings = master["warnings"]
+    pr_warnings = pr["warnings"]
+
+    push!(lines, "### JET Report Comparison")
     push!(lines, "")
-    for (i, issue) in enumerate(fixed_issues)
-        sig = issue["signature"]
-        push!(
-            lines, "<details><summary>$(i). $(issue["type"]) — $(basename(sig))</summary>"
-        )
-        push!(lines, "")
-        push!(lines, "```")
-        msg = issue["message"]
-        if length(msg) > 500
-            msg = msg[1:500] * "…"
-        end
-        push!(lines, msg)
-        push!(lines, "```")
-        push!(lines, "</details>")
-        push!(lines, "")
-    end
-end
+    push!(lines, "| | Master | PR | Δ |")
+    push!(lines, "|---|---|---|---|")
+    push!(
+        lines,
+        "| Total issues | $(master_total) | $(pr_total) | $(pr_total - master_total) |",
+    )
+    push!(
+        lines, "| Errors | $(master_errors) | $(pr_errors) | $(pr_errors - master_errors) |"
+    )
+    push!(
+        lines,
+        "| Warnings | $(master_warnings) | $(pr_warnings) | $(pr_warnings - master_warnings) |",
+    )
+    push!(lines, "")
 
-if isempty(new_issues) && isempty(fixed_issues)
-    push!(lines, "No new or fixed issues.")
-end
-
-# Full issue lists only when --full is passed (push to master)
-if full_report
-    all_master_issues = sort(collect(values(master_issues)); by=i -> i["signature"])
-    if !isempty(all_master_issues)
+    if !isempty(new_issues)
+        push!(lines, "#### ⚠️ New issues ($(length(new_issues)))")
         push!(lines, "")
-        push!(lines, "#### 📋 All issues on master ($(length(all_master_issues)))")
-        push!(lines, "")
-        for (i, issue) in enumerate(all_master_issues)
-            sig = issue["signature"]
-            msg = issue["message"]
-            if length(msg) > 500
-                msg = msg[1:500] * "…"
-            end
-            push!(
-                lines,
-                "<details><summary>$(i). $(issue["type"]) — $(basename(sig))</summary>",
-            )
-            push!(lines, "")
-            push!(lines, "```")
-            push!(lines, msg)
-            push!(lines, "```")
-            push!(lines, "</details>")
-            push!(lines, "")
+        for (i, issue) in enumerate(new_issues)
+            append!(lines, issue_block(i, issue))
         end
     end
 
-    all_pr_issues = sort(collect(values(pr_issues)); by=i -> i["signature"])
-    if !isempty(all_pr_issues)
+    if !isempty(fixed_issues)
+        push!(lines, "#### ✅ Fixed issues ($(length(fixed_issues)))")
         push!(lines, "")
-        push!(lines, "#### 📋 All issues in PR ($(length(all_pr_issues)))")
-        push!(lines, "")
-        for (i, issue) in enumerate(all_pr_issues)
-            sig = issue["signature"]
-            msg = issue["message"]
-            if length(msg) > 500
-                msg = msg[1:500] * "…"
-            end
-            push!(
-                lines,
-                "<details><summary>$(i). $(issue["type"]) — $(basename(sig))</summary>",
-            )
-            push!(lines, "")
-            push!(lines, "```")
-            push!(lines, msg)
-            push!(lines, "```")
-            push!(lines, "</details>")
-            push!(lines, "")
+        for (i, issue) in enumerate(fixed_issues)
+            append!(lines, issue_block(i, issue))
         end
+    end
+
+    if isempty(new_issues) && isempty(fixed_issues)
+        push!(lines, "No new or fixed issues.")
     end
 end
 


### PR DESCRIPTION
## Summary

Two related cleanups:

### 1. Complete API documentation
- Added docstrings and `@docs` entries for every previously-undocumented export:
  - Problem accessors: `getdim`, `floattype`, `getdh`, `getk`, `getcloaddict`, `getfacesets`, `getpressuredict`, `getheatfluxdict`
  - `AbstractFunction`, `AbstractTopOptProblem`, `TieBeamGrid`, `YoungsModulus`, `PoissonRatio`
  - `TemperatureFun` and `cell_temperature` (added in #323)
  - Trace-estimation helpers (`generate_scenarios`, `hutch_rand!`, `hadamard!`) and neural containers (`AbstractMLModel`, `Coordinates`, `NNParams`, `getcentroids`)
  - Low-level helpers (`RaggedArray`, `compliance`, `sumdiag`, `meandiag`, `getsolver`, `@debug`, `@forward_property`, `cg_solve!`, `assemble`, `assemble_f!`)
- Added a "Nodal temperature" section to the narrative `functions.md`.
- Added prose intros to the problem-type docstrings (fixes "no prose paragraph" tooltip warnings).
- Docs now build cleanly under `checkdocs=:all` (verified with `makedocs`).

### 2. Simplify the JET report comment
- Commit-to-master JET comment now lists the issues directly (or "No JET issues found." when clean) instead of the Master/PR comparison table.
- PR comments keep the Master/PR comparison table.
- Both always post.

*Prepared with assistance from deepseek-v4-pro via opencode.*